### PR TITLE
Add astropy-specific schemas to repo

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,16 +1,6 @@
-include README.rst
-include CHANGES.rst
-include setup.cfg
-include LICENSE.rst
-include pyproject.toml
-
-recursive-include asdf-astropy *.pyx *.c *.pxd
-recursive-include docs *
-recursive-include licenses *
-recursive-include scripts *
-
-prune build
 prune docs/_build
 prune docs/api
 
-global-exclude *.pyc *.o
+global-exclude *.pyc
+
+exclude .*

--- a/asdf_astropy/integration.py
+++ b/asdf_astropy/integration.py
@@ -1,0 +1,24 @@
+import sys
+
+from asdf.resource import DirectoryResourceMapping
+
+if sys.version_info < (3, 9):
+    import importlib_resources
+else:
+    import importlib.resources as importlib_resources
+
+from . import resources
+
+
+def get_resource_mappings():
+    """
+    Get the resource mapping instances for the astropy schemas
+    and manifests.  This method is registered with the
+    asdf.resource_mappings entry point.
+    """
+    resources_root = importlib_resources.files(resources)
+
+    return [
+        DirectoryResourceMapping(resources_root / "schemas", "http://astropy.org/schemas/astropy", recursive=True),
+        DirectoryResourceMapping(resources_root / "manifests", "http://astropy.org/asdf/extensions/astropy/manifests"),
+    ]

--- a/asdf_astropy/resources/manifests/astropy-1.0.yaml
+++ b/asdf_astropy/resources/manifests/astropy-1.0.yaml
@@ -1,0 +1,131 @@
+id: http://astropy.org/asdf/extensions/astropy/manifests/astropy-1.0
+extension_uri: http://astropy.org/asdf/extensions/astropy-1.0
+title: Astropy extension 1.0
+description: |-
+  A set of tags for serializing astropy objects.  This does not include most
+  model classes, which are handled by an implementation of the ASDF
+  transform extension.
+asdf_standard_requirement:
+  gte: 1.1.0
+tags:
+- tag_uri: tag:astropy.org:astropy/coordinates/longitude-1.0.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/longitude-1.0.0
+  title: Represents longitude-like angles.
+  description: |-
+    Longitude-like angle(s) which are wrapped within a contiguous 360 degree range.
+- tag_uri: tag:astropy.org:astropy/coordinates/spectralcoord-1.0.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/spectralcoord-1.0.0
+  title: Represents a SpectralCoord object from astropy
+- tag_uri: tag:astropy.org:astropy/coordinates/latitude-1.0.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/latitude-1.0.0
+  title: Represents latitude-like angles.
+  description: |-
+    Represents latitude-like angle(s) which must be in the range -90 to +90 deg.
+- tag_uri: tag:astropy.org:astropy/coordinates/representation-1.0.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/representation-1.0.0
+  title: Representation of points or differentials in two or three dimensional space.
+  description: |-
+    Representation of points or differentials in two or three dimensional space.
+- tag_uri: tag:astropy.org:astropy/coordinates/skycoord-1.0.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/skycoord-1.0.0
+  title: Represents a SkyCoord object from astropy
+- tag_uri: tag:astropy.org:astropy/coordinates/angle-1.0.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/angle-1.0.0
+  title: Represents an Angle.
+  description: |-
+    This object represents a subtype of Quantity which has units equivalent to radians or degrees.
+- tag_uri: tag:astropy.org:astropy/coordinates/earthlocation-1.0.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/earthlocation-1.0.0
+  title: Represents EarthLocation objects from astropy.
+  description: |-
+    Location on the Earth.
+- tag_uri: tag:astropy.org:astropy/coordinates/frames/fk5-1.0.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/frames/fk5-1.0.0
+  title: Represents a FK5 coordinate object from astropy
+- tag_uri: tag:astropy.org:astropy/coordinates/frames/itrs-1.0.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/frames/itrs-1.0.0
+  title: Represents a ITRS coordinate object from astropy
+- tag_uri: tag:astropy.org:astropy/coordinates/frames/icrs-1.1.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/frames/icrs-1.1.0
+  title: Represents an ICRS coordinate object from astropy.
+- tag_uri: tag:astropy.org:astropy/coordinates/frames/galactocentric-1.0.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/frames/galactocentric-1.0.0
+  title: Represents an galactocentric coordinate object from astropy
+- tag_uri: tag:astropy.org:astropy/coordinates/frames/baseframe-1.0.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/frames/baseframe-1.0.0
+  title: Represents a coordinate frame object from astropy
+  description: |-
+    This schema is designed to be extended by other schemas to restrict the
+    allowable frame_attributes.
+- tag_uri: tag:astropy.org:astropy/coordinates/frames/precessedgeocentric-1.0.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/frames/precessedgeocentric-1.0.0
+  title: Represents a PrecessedGeocentric coordinate object from astropy
+- tag_uri: tag:astropy.org:astropy/coordinates/frames/galactic-1.0.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/frames/galactic-1.0.0
+  title: Represents an Galactic coordinate object from astropy.
+- tag_uri: tag:astropy.org:astropy/coordinates/frames/fk4noeterms-1.0.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/frames/fk4noeterms-1.0.0
+  title: Represents a FK4NoETerms coordinate object from astropy
+- tag_uri: tag:astropy.org:astropy/coordinates/frames/icrs-1.0.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/frames/icrs-1.0.0
+  title: Represents an ICRS coordinate object from astropy
+  description: |-
+    This object represents the right ascension (RA) and declination of an ICRS
+    coordinate or frame. The ICRS class contains additional fields that may be
+    useful to add here in the future.
+- tag_uri: tag:astropy.org:astropy/coordinates/frames/cirs-1.0.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/frames/cirs-1.0.0
+  title: Represents a CIRS coordinate object from astropy
+- tag_uri: tag:astropy.org:astropy/coordinates/frames/fk4-1.0.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/frames/fk4-1.0.0
+  title: Represents a FK4 coordinate object from astropy
+- tag_uri: tag:astropy.org:astropy/coordinates/frames/gcrs-1.0.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/frames/gcrs-1.0.0
+  title: Represents a GCRS coordinate object from astropy
+- tag_uri: tag:astropy.org:astropy/time/timedelta-1.0.0
+  schema_uri: http://astropy.org/schemas/astropy/time/timedelta-1.0.0
+  title: Represents an instance of TimeDelta from astropy
+  description: |-
+    Represents the time difference between two times.
+- tag_uri: tag:astropy.org:astropy/units/equivalency-1.0.0
+  schema_uri: http://astropy.org/schemas/astropy/units/equivalency-1.0.0
+  title: Represents unit equivalency.
+  description: |-
+    Supports serialization of equivalencies between units
+    in certain contexts
+- tag_uri: tag:astropy.org:astropy/fits/fits-1.0.0
+  schema_uri: http://astropy.org/schemas/astropy/fits/fits-1.0.0
+  title: A FITS file inside of an ASDF file.
+  description: |-
+    This schema is useful for distributing ASDF files that can
+    automatically be converted to FITS files by specifying the exact
+    content of the resulting FITS file.
+
+    Not all kinds of data in FITS are directly representable in ASDF.
+    For example, applying an offset and scale to the data using the
+    `BZERO` and `BSCALE` keywords.  In these cases, it will not be
+    possible to store the data in the native format from FITS and also
+    be accessible in its proper form in the ASDF file.
+
+    Only image and binary table extensions are supported.
+- tag_uri: tag:astropy.org:astropy/table/table-1.0.0
+  schema_uri: http://astropy.org/schemas/astropy/table/table-1.0.0
+  title: A table.
+  description: |-
+    A table is represented as a list of columns, where each entry is a
+    [column](ref:http://stsci.edu/schemas/asdf/core/column-1.0.0)
+    object, containing the data and some additional information.
+
+    The data itself may be stored inline as text, or in binary in either
+    row- or column-major order by use of the `strides` property on the
+    individual column arrays.
+
+    Each column in the table must have the same first (slowest moving)
+    dimension.
+- tag_uri: tag:astropy.org:astropy/transform/units_mapping-1.0.0
+  schema_uri: http://astropy.org/schemas/astropy/transform/units_mapping-1.0.0
+  title: Mapper that operates on the units of the input.
+  description: |-
+    This transform operates on the units of the input, first converting to
+    the expected input units, then assigning replacement output units without
+    further conversion.

--- a/asdf_astropy/resources/schemas/coordinates/angle-1.0.0.yaml
+++ b/asdf_astropy/resources/schemas/coordinates/angle-1.0.0.yaml
@@ -1,0 +1,35 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/angle-1.0.0"
+tag: "tag:astropy.org:astropy/coordinates/angle-1.0.0"
+
+title: |
+  Represents an Angle.
+
+description:
+  This object represents a subtype of Quantity which has units equivalent to
+  radians or degrees.
+
+examples:
+  -
+    - An Angle object in Degrees
+    - |
+        !<tag:astropy.org:astropy/coordinates/angle-1.0.0>
+          unit: !unit/unit-1.0.0 deg
+          value: 10.0
+
+type: object
+properties:
+  value:
+    description: |
+      A vector of one or more values
+    anyOf:
+      - type: number
+      - $ref: "http://stsci.edu/schemas/asdf/core/ndarray-1.0.0"
+  unit:
+    description: |
+      The unit corresponding to the values
+    $ref: "http://stsci.edu/schemas/asdf/unit/unit-1.0.0"
+required: [value, unit]
+...

--- a/asdf_astropy/resources/schemas/coordinates/earthlocation-1.0.0.yaml
+++ b/asdf_astropy/resources/schemas/coordinates/earthlocation-1.0.0.yaml
@@ -1,0 +1,35 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/earthlocation-1.0.0"
+tag: "tag:astropy.org:astropy/coordinates/earthlocation-1.0.0"
+
+title: |
+  Represents EarthLocation objects from astropy.
+
+description: |
+  Location on the Earth.
+
+type: object
+properties:
+  x:
+    description: |
+      X component of location in geocentric representation
+    $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+  y:
+    description: |
+      Y component of location in geocentric representation
+    $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+  z:
+    description: |
+      Z component of location in geocentric representation
+    $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+  ellipsoid:
+    description: |
+      Reference ellipsoid that is used when representing geodetic coordinates.
+    type: string
+    enum: [WGS84, GRS80, WGS72]
+
+required: [x, y, z]
+additionalProperties: False
+...

--- a/asdf_astropy/resources/schemas/coordinates/frames/baseframe-1.0.0.yaml
+++ b/asdf_astropy/resources/schemas/coordinates/frames/baseframe-1.0.0.yaml
@@ -1,0 +1,27 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/frames/baseframe-1.0.0"
+
+title: |
+  Represents a coordinate frame object from astropy
+
+description: |
+  This schema is designed to be extended by other schemas to restrict the
+  allowable frame_attributes.
+
+type: object
+properties:
+  data:
+    description: |
+      The representation object holding any data associated with the frame.
+    $ref: "../representation-1.0.0"
+  frame_attributes:
+    description: |
+      Attributes on the coordinate frame.
+    type: object
+
+
+additionalProperties: false
+required: [frame_attributes]
+...

--- a/asdf_astropy/resources/schemas/coordinates/frames/cirs-1.0.0.yaml
+++ b/asdf_astropy/resources/schemas/coordinates/frames/cirs-1.0.0.yaml
@@ -1,0 +1,43 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/frames/cirs-1.0.0"
+tag: "tag:astropy.org:astropy/coordinates/frames/cirs-1.0.0"
+
+title: |
+  Represents a CIRS coordinate object from astropy
+
+examples:
+  -
+    - A CIRS frame without data
+    - |
+        !<tag:astropy.org:astropy/coordinates/frames/cirs-1.0.0>
+          frame_attributes:
+            obstime: !time/time-1.1.0 {scale: tai, value: B1950.000}
+  -
+    - A CIRS frame with data
+    - |
+        !<tag:astropy.org:astropy/coordinates/frames/cirs-1.0.0>
+          data: !<tag:astropy.org:astropy/coordinates/representation-1.0.0>
+            components:
+              lat: !<tag:astropy.org:astropy/coordinates/latitude-1.0.0> {unit: !unit/unit-1.0.0 deg,
+                value: 10.0}
+              lon: !<tag:astropy.org:astropy/coordinates/longitude-1.0.0>
+                unit: !unit/unit-1.0.0 deg
+                value: 120.0
+                wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.0.0> {unit: !unit/unit-1.0.0 deg,
+                  value: 360.0}
+            type: UnitSphericalRepresentation
+          frame_attributes:
+            obstime: !time/time-1.1.0 {scale: tai, value: B1950.000}
+
+allOf:
+  - $ref: baseframe-1.0.0
+  - properties:
+      frame_attributes:
+        type: object
+        properties:
+          obstime:
+            $ref: "http://stsci.edu/schemas/asdf/time/time-1.1.0"
+        required: [obstime]
+...

--- a/asdf_astropy/resources/schemas/coordinates/frames/fk4-1.0.0.yaml
+++ b/asdf_astropy/resources/schemas/coordinates/frames/fk4-1.0.0.yaml
@@ -1,0 +1,47 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/frames/fk4-1.0.0"
+tag: "tag:astropy.org:astropy/coordinates/frames/fk4-1.0.0"
+
+title: |
+  Represents a FK4 coordinate object from astropy
+
+examples:
+  -
+    - A FK4 frame without data
+    - |
+        !<tag:astropy.org:astropy/coordinates/frames/fk4-1.0.0>
+          frame_attributes:
+            equinox: !time/time-1.1.0 {scale: tai, value: B1950.000}
+            obstime: !time/time-1.1.0 {scale: tai, value: B1950.000}
+  -
+    - A FK4 frame with data
+    - |
+        !<tag:astropy.org:astropy/coordinates/frames/fk4-1.0.0>
+          data: !<tag:astropy.org:astropy/coordinates/representation-1.0.0>
+            components:
+              lat: !<tag:astropy.org:astropy/coordinates/latitude-1.0.0> {unit: !unit/unit-1.0.0 deg,
+                value: 10.0}
+              lon: !<tag:astropy.org:astropy/coordinates/longitude-1.0.0>
+                unit: !unit/unit-1.0.0 deg
+                value: 120.0
+                wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.0.0> {unit: !unit/unit-1.0.0 deg,
+                  value: 360.0}
+            type: UnitSphericalRepresentation
+          frame_attributes:
+            equinox: !time/time-1.1.0 {scale: tai, value: B1950.000}
+            obstime: !time/time-1.1.0 {scale: tai, value: B1950.000}
+
+allOf:
+  - $ref: baseframe-1.0.0
+  - properties:
+      frame_attributes:
+        type: object
+        properties:
+          equinox:
+            $ref: "http://stsci.edu/schemas/asdf/time/time-1.1.0"
+          obstime:
+            $ref: "http://stsci.edu/schemas/asdf/time/time-1.1.0"
+        required: [equinox]
+...

--- a/asdf_astropy/resources/schemas/coordinates/frames/fk4noeterms-1.0.0.yaml
+++ b/asdf_astropy/resources/schemas/coordinates/frames/fk4noeterms-1.0.0.yaml
@@ -1,0 +1,47 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/frames/fk4noeterms-1.0.0"
+tag: "tag:astropy.org:astropy/coordinates/frames/fk4noeterms-1.0.0"
+
+title: |
+  Represents a FK4NoETerms coordinate object from astropy
+
+examples:
+  -
+    - A FK4NoETerms frame without data
+    - |
+        !<tag:astropy.org:astropy/coordinates/frames/fk4noeterms-1.0.0>
+          frame_attributes:
+            equinox: !time/time-1.1.0 {scale: tai, value: B1950.000}
+            obstime: !time/time-1.1.0 {scale: tai, value: B1950.000}
+  -
+    - A FK4NoETerms frame with data
+    - |
+        !<tag:astropy.org:astropy/coordinates/frames/fk4noeterms-1.0.0>
+          data: !<tag:astropy.org:astropy/coordinates/representation-1.0.0>
+            components:
+              lat: !<tag:astropy.org:astropy/coordinates/latitude-1.0.0> {unit: !unit/unit-1.0.0 deg,
+                value: 10.0}
+              lon: !<tag:astropy.org:astropy/coordinates/longitude-1.0.0>
+                unit: !unit/unit-1.0.0 deg
+                value: 120.0
+                wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.0.0> {unit: !unit/unit-1.0.0 deg,
+                  value: 360.0}
+            type: UnitSphericalRepresentation
+          frame_attributes:
+            equinox: !time/time-1.1.0 {scale: tai, value: B1950.000}
+            obstime: !time/time-1.1.0 {scale: tai, value: B1950.000}
+
+allOf:
+  - $ref: baseframe-1.0.0
+  - properties:
+      frame_attributes:
+        type: object
+        properties:
+          equinox:
+            $ref: "http://stsci.edu/schemas/asdf/time/time-1.1.0"
+          obstime:
+            $ref: "http://stsci.edu/schemas/asdf/time/time-1.1.0"
+        required: [equinox]
+...

--- a/asdf_astropy/resources/schemas/coordinates/frames/fk5-1.0.0.yaml
+++ b/asdf_astropy/resources/schemas/coordinates/frames/fk5-1.0.0.yaml
@@ -1,0 +1,41 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/frames/fk5-1.0.0"
+tag: "tag:astropy.org:astropy/coordinates/frames/fk5-1.0.0"
+
+title: |
+  Represents a FK5 coordinate object from astropy
+
+examples:
+  -
+    - A FK5 frame without data with a custom equinox
+    - |
+        !<tag:astropy.org:astropy/coordinates/frames/fk5-1.0.0>
+          frame_attributes: {equinox: !time/time-1.1.0 '2011-01-02 00:00:00.000'}
+  -
+    - A FK5 frame with data
+    - |
+        !<tag:astropy.org:astropy/coordinates/frames/fk5-1.0.0>
+          data: !<tag:astropy.org:astropy/coordinates/representation-1.0.0>
+            components:
+              lat: !<tag:astropy.org:astropy/coordinates/latitude-1.0.0> {unit: !unit/unit-1.0.0 deg,
+                value: 10.0}
+              lon: !<tag:astropy.org:astropy/coordinates/longitude-1.0.0>
+                unit: !unit/unit-1.0.0 deg
+                value: 120.0
+                wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.0.0> {unit: !unit/unit-1.0.0 deg,
+                  value: 360.0}
+            type: UnitSphericalRepresentation
+          frame_attributes: {equinox: !time/time-1.1.0 J2000.000}
+
+allOf:
+  - $ref: baseframe-1.0.0
+  - properties:
+      frame_attributes:
+        type: object
+        properties:
+          equinox:
+            $ref: "http://stsci.edu/schemas/asdf/time/time-1.1.0"
+        required: [equinox]
+...

--- a/asdf_astropy/resources/schemas/coordinates/frames/galactic-1.0.0.yaml
+++ b/asdf_astropy/resources/schemas/coordinates/frames/galactic-1.0.0.yaml
@@ -1,0 +1,37 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/frames/galactic-1.0.0"
+tag: "tag:astropy.org:astropy/coordinates/frames/galactic-1.0.0"
+
+title: |
+  Represents an Galactic coordinate object from astropy.
+
+examples:
+  -
+    - An Galactic frame without data
+    - |
+         !<tag:astropy.org:astropy/coordinates/frames/galactic-1.0.0>
+           frame_attributes: {}
+  -
+    - An Galactic frame with data
+    - |
+         !<tag:astropy.org:astropy/coordinates/frames/galactic-1.0.0>
+           data: !<tag:astropy.org:astropy/coordinates/representation-1.0.0>
+             components:
+               lat: !<tag:astropy.org:astropy/coordinates/latitude-1.0.0> {unit: !unit/unit-1.0.0 deg,
+                 value: 2.0}
+               lon: !<tag:astropy.org:astropy/coordinates/longitude-1.0.0>
+                 unit: !unit/unit-1.0.0 deg
+                 value: 1.0
+                 wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.0.0> {unit: !unit/unit-1.0.0 deg,
+                   value: 360.0}
+             type: UnitSphericalRepresentation
+           frame_attributes: {}
+
+
+
+
+allOf:
+  - $ref: baseframe-1.0.0
+...

--- a/asdf_astropy/resources/schemas/coordinates/frames/galactocentric-1.0.0.yaml
+++ b/asdf_astropy/resources/schemas/coordinates/frames/galactocentric-1.0.0.yaml
@@ -1,0 +1,56 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/frames/galactocentric-1.0.0"
+tag: "tag:astropy.org:astropy/coordinates/frames/galactocentric-1.0.0"
+
+title: |
+  Represents an galactocentric coordinate object from astropy
+
+examples:
+  -
+    - A Galactocentric frame without data
+    - |
+        !<tag:astropy.org:astropy/coordinates/frames/galactocentric-1.0.0>
+          frame_attributes:
+            galcen_coord: !<tag:astropy.org:astropy/coordinates/frames/icrs-1.1.0>
+              data: !<tag:astropy.org:astropy/coordinates/representation-1.0.0>
+                components:
+                  lat: !<tag:astropy.org:astropy/coordinates/latitude-1.0.0> {unit: !unit/unit-1.0.0 deg,
+                    value: -28.936175}
+                  lon: !<tag:astropy.org:astropy/coordinates/longitude-1.0.0>
+                    unit: !unit/unit-1.0.0 deg
+                    value: 266.4051
+                    wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.0.0> {unit: !unit/unit-1.0.0 deg,
+                      value: 360.0}
+                type: UnitSphericalRepresentation
+              frame_attributes: {}
+            galcen_distance: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 kpc, value: 8.3}
+            galcen_v_sun: !<tag:astropy.org:astropy/coordinates/representation-1.0.0>
+              components:
+                d_x: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 km s-1, value: 11.1}
+                d_y: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 km s-1, value: 232.24}
+                d_z: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 km s-1, value: 7.25}
+              type: CartesianDifferential
+            roll: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 deg, value: 0.0}
+            z_sun: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 pc, value: 27.0}
+
+allOf:
+  - $ref: baseframe-1.0.0
+  - properties:
+      frame_attributes:
+        type: object
+        properties:
+          galacen_coord:
+            $ref: "icrs-1.1.0"
+          galcen_distance:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+          galcen_v_sun:
+            $ref: "../representation-1.0.0"
+          z_sun:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+          roll:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+
+        required: [galcen_coord, galcen_distance, galcen_v_sun, z_sun, roll]
+...

--- a/asdf_astropy/resources/schemas/coordinates/frames/gcrs-1.0.0.yaml
+++ b/asdf_astropy/resources/schemas/coordinates/frames/gcrs-1.0.0.yaml
@@ -1,0 +1,70 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/frames/gcrs-1.0.0"
+tag: "tag:astropy.org:astropy/coordinates/frames/gcrs-1.0.0"
+
+title: |
+  Represents a GCRS coordinate object from astropy
+
+examples:
+  -
+    - A GCRS frame without data
+    - |
+        !<tag:astropy.org:astropy/coordinates/frames/gcrs-1.0.0>
+            frame_attributes:
+              obsgeoloc: !<tag:astropy.org:astropy/coordinates/representation-1.0.0>
+                components:
+                  x: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m, value: 0.0}
+                  y: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m, value: 0.0}
+                  z: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m, value: 0.0}
+                type: CartesianRepresentation
+              obsgeovel: !<tag:astropy.org:astropy/coordinates/representation-1.0.0>
+                components:
+                  x: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m s-1, value: 0.0}
+                  y: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m s-1, value: 0.0}
+                  z: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m s-1, value: 0.0}
+                type: CartesianRepresentation
+              obstime: !time/time-1.1.0 J2000.000
+  -
+    - A GCRS frame with data
+    - |
+        !<tag:astropy.org:astropy/coordinates/frames/gcrs-1.0.0>
+          data: !<tag:astropy.org:astropy/coordinates/representation-1.0.0>
+            components:
+              lat: !<tag:astropy.org:astropy/coordinates/latitude-1.0.0> {unit: !unit/unit-1.0.0 deg,
+                value: 2.0}
+              lon: !<tag:astropy.org:astropy/coordinates/longitude-1.0.0>
+                unit: !unit/unit-1.0.0 deg
+                value: 1.0
+                wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.0.0> {unit: !unit/unit-1.0.0 deg,
+                  value: 360.0}
+            type: UnitSphericalRepresentation
+          frame_attributes:
+            obsgeoloc: !<tag:astropy.org:astropy/coordinates/representation-1.0.0>
+              components:
+                x: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m, value: 0.0}
+                y: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m, value: 0.0}
+                z: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m, value: 0.0}
+              type: CartesianRepresentation
+            obsgeovel: !<tag:astropy.org:astropy/coordinates/representation-1.0.0>
+              components:
+                x: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m s-1, value: 0.0}
+                y: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m s-1, value: 0.0}
+                z: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m s-1, value: 0.0}
+              type: CartesianRepresentation
+            obstime: !time/time-1.1.0 J2000.000
+
+allOf:
+  - $ref: baseframe-1.0.0
+  - properties:
+      frame_attributes:
+        type: object
+        properties:
+          obstime:
+            $ref: "http://stsci.edu/schemas/asdf/time/time-1.1.0"
+          obsgeoloc:
+            $ref: "../representation-1.0.0"
+          obsgeovel:
+            $ref: "../representation-1.0.0"
+...

--- a/asdf_astropy/resources/schemas/coordinates/frames/icrs-1.0.0.yaml
+++ b/asdf_astropy/resources/schemas/coordinates/frames/icrs-1.0.0.yaml
@@ -1,0 +1,42 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/frames/icrs-1.0.0"
+tag: "tag:astropy.org:astropy/coordinates/frames/icrs-1.0.0"
+
+title: |
+  Represents an ICRS coordinate object from astropy
+
+description: |
+  This object represents the right ascension (RA) and declination of an ICRS
+  coordinate or frame. The ICRS class contains additional fields that may be
+  useful to add here in the future.
+
+type: object
+properties:
+  ra:
+    type: object
+    description: |
+      A longitude representing the right ascension of the ICRS coordinate
+    properties:
+      value:
+        type: number
+      unit:
+        $ref: "http://stsci.edu/schemas/asdf/unit/unit-1.0.0"
+        default: deg
+      wrap_angle:
+        $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+        default: "360 deg"
+  dec:
+    type: object
+    description: |
+      A latitude representing the declination of the ICRS coordinate
+    properties:
+      value:
+        type: number
+      unit:
+        $ref: "http://stsci.edu/schemas/asdf/unit/unit-1.0.0"
+        default: deg
+
+required: [ra, dec]
+...

--- a/asdf_astropy/resources/schemas/coordinates/frames/icrs-1.1.0.yaml
+++ b/asdf_astropy/resources/schemas/coordinates/frames/icrs-1.1.0.yaml
@@ -1,0 +1,36 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/frames/icrs-1.1.0"
+tag: "tag:astropy.org:astropy/coordinates/frames/icrs-1.1.0"
+
+title: |
+  Represents an ICRS coordinate object from astropy.
+
+examples:
+  -
+    - An ICRS frame without data
+    - |
+        !<tag:astropy.org:astropy/coordinates/frames/icrs-1.1.0>
+          frame_attributes: {}
+  -
+    - An ICRS frame with data
+    - |
+        !<tag:astropy.org:astropy/coordinates/frames/icrs-1.1.0>
+          data: !<tag:astropy.org:astropy/coordinates/representation-1.0.0>
+            components:
+              lat: !<tag:astropy.org:astropy/coordinates/latitude-1.0.0> {unit: !unit/unit-1.0.0 deg,
+                value: 10.0}
+              lon: !<tag:astropy.org:astropy/coordinates/longitude-1.0.0>
+                unit: !unit/unit-1.0.0 deg
+                value: 120.0
+                wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.0.0> {unit: !unit/unit-1.0.0 deg,
+                  value: 360.0}
+            type: UnitSphericalRepresentation
+          frame_attributes: {}
+
+
+
+allOf:
+  - $ref: baseframe-1.0.0
+...

--- a/asdf_astropy/resources/schemas/coordinates/frames/itrs-1.0.0.yaml
+++ b/asdf_astropy/resources/schemas/coordinates/frames/itrs-1.0.0.yaml
@@ -1,0 +1,43 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/frames/itrs-1.0.0"
+tag: "tag:astropy.org:astropy/coordinates/frames/itrs-1.0.0"
+
+title: |
+  Represents a ITRS coordinate object from astropy
+
+examples:
+  -
+    - A ITRS frame without data
+    - |
+        !<tag:astropy.org:astropy/coordinates/frames/itrs-1.0.0>
+          frame_attributes:
+            obstime: !time/time-1.1.0 {scale: tai, value: B1950.000}
+  -
+    - A ITRS frame with data
+    - |
+        !<tag:astropy.org:astropy/coordinates/frames/itrs-1.0.0>
+          data: !<tag:astropy.org:astropy/coordinates/representation-1.0.0>
+            components:
+              lat: !<tag:astropy.org:astropy/coordinates/latitude-1.0.0> {unit: !unit/unit-1.0.0 deg,
+                value: 10.0}
+              lon: !<tag:astropy.org:astropy/coordinates/longitude-1.0.0>
+                unit: !unit/unit-1.0.0 deg
+                value: 120.0
+                wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.0.0> {unit: !unit/unit-1.0.0 deg,
+                  value: 360.0}
+            type: UnitSphericalRepresentation
+          frame_attributes:
+            obstime: !time/time-1.1.0 {scale: tai, value: B1950.000}
+
+allOf:
+  - $ref: baseframe-1.0.0
+  - properties:
+      frame_attributes:
+        type: object
+        properties:
+          obstime:
+            $ref: "http://stsci.edu/schemas/asdf/time/time-1.1.0"
+        required: [obstime]
+...

--- a/asdf_astropy/resources/schemas/coordinates/frames/precessedgeocentric-1.0.0.yaml
+++ b/asdf_astropy/resources/schemas/coordinates/frames/precessedgeocentric-1.0.0.yaml
@@ -1,0 +1,74 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/frames/precessedgeocentric-1.0.0"
+tag: "tag:astropy.org:astropy/coordinates/frames/precessedgeocentric-1.0.0"
+
+title: |
+  Represents a PrecessedGeocentric coordinate object from astropy
+
+examples:
+  -
+    - A PrecessedGeocentric frame without data
+    - |
+        !<tag:astropy.org:astropy/coordinates/frames/precessedgeocentric-1.0.0>
+          frame_attributes:
+            equinox: !time/time-1.1.0 J2000.000
+            obsgeoloc: !<tag:astropy.org:astropy/coordinates/representation-1.0.0>
+              components:
+                x: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m, value: 0.0}
+                y: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m, value: 0.0}
+                z: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m, value: 0.0}
+              type: CartesianRepresentation
+            obsgeovel: !<tag:astropy.org:astropy/coordinates/representation-1.0.0>
+              components:
+                x: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m s-1, value: 0.0}
+                y: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m s-1, value: 0.0}
+                z: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m s-1, value: 0.0}
+              type: CartesianRepresentation
+            obstime: !time/time-1.1.0 J2000.000
+  -
+    - A PrecessedGeocentric frame with data
+    - |
+        !<tag:astropy.org:astropy/coordinates/frames/precessedgeocentric-1.0.0>
+            data: !<tag:astropy.org:astropy/coordinates/representation-1.0.0>
+              components:
+                lat: !<tag:astropy.org:astropy/coordinates/latitude-1.0.0> {unit: !unit/unit-1.0.0 deg,
+                  value: 1.0}
+                lon: !<tag:astropy.org:astropy/coordinates/longitude-1.0.0>
+                  unit: !unit/unit-1.0.0 deg
+                  value: 1.0
+                  wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.0.0> {unit: !unit/unit-1.0.0 deg,
+                    value: 360.0}
+              type: UnitSphericalRepresentation
+            frame_attributes:
+              equinox: !time/time-1.1.0 J2000.000
+              obsgeoloc: !<tag:astropy.org:astropy/coordinates/representation-1.0.0>
+                components:
+                  x: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m, value: 0.0}
+                  y: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m, value: 0.0}
+                  z: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m, value: 0.0}
+                type: CartesianRepresentation
+              obsgeovel: !<tag:astropy.org:astropy/coordinates/representation-1.0.0>
+                components:
+                  x: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m s-1, value: 0.0}
+                  y: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m s-1, value: 0.0}
+                  z: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 m s-1, value: 0.0}
+                type: CartesianRepresentation
+              obstime: !time/time-1.1.0 J2000.000
+
+allOf:
+  - $ref: baseframe-1.0.0
+  - properties:
+      frame_attributes:
+        type: object
+        properties:
+          equinox:
+            $ref: "http://stsci.edu/schemas/asdf/time/time-1.1.0"
+          obstime:
+            $ref: "http://stsci.edu/schemas/asdf/time/time-1.1.0"
+          obsgeoloc:
+            $ref: "../representation-1.0.0"
+          obsgeovel:
+            $ref: "../representation-1.0.0"
+...

--- a/asdf_astropy/resources/schemas/coordinates/latitude-1.0.0.yaml
+++ b/asdf_astropy/resources/schemas/coordinates/latitude-1.0.0.yaml
@@ -1,0 +1,34 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/latitude-1.0.0"
+tag: "tag:astropy.org:astropy/coordinates/latitude-1.0.0"
+
+title: |
+  Represents latitude-like angles.
+
+description: |
+  Represents latitude-like angle(s) which must be in the range -90 to +90 deg.
+
+examples:
+  -
+    - A Latitude object in Degrees
+    - |
+        !<tag:astropy.org:astropy/coordinates/latitude-1.0.0>
+          unit: !unit/unit-1.0.0 deg
+          value: 10.0
+
+type: object
+properties:
+  value:
+    description: |
+      A vector of one or more values
+    anyOf:
+      - type: number
+      - $ref: "http://stsci.edu/schemas/asdf/core/ndarray-1.0.0"
+  unit:
+    description: |
+      The unit corresponding to the values
+    $ref: "http://stsci.edu/schemas/asdf/unit/unit-1.0.0"
+required: [value, unit]
+...

--- a/asdf_astropy/resources/schemas/coordinates/longitude-1.0.0.yaml
+++ b/asdf_astropy/resources/schemas/coordinates/longitude-1.0.0.yaml
@@ -1,0 +1,42 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/longitude-1.0.0"
+tag: "tag:astropy.org:astropy/coordinates/longitude-1.0.0"
+
+title: |
+  Represents longitude-like angles.
+
+description: |
+    Longitude-like angle(s) which are wrapped within a contiguous 360 degree range.
+
+examples:
+  -
+    - A Longitude object in Degrees
+    - |
+        !<tag:astropy.org:astropy/coordinates/longitude-1.0.0>
+          unit: !unit/unit-1.0.0 deg
+          value: 10.0
+          wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.0.0>
+            unit: !unit/unit-1.0.0 deg
+            value: 180.0
+
+type: object
+properties:
+  value:
+    description: |
+      A vector of one or more values
+    anyOf:
+      - type: number
+      - $ref: "http://stsci.edu/schemas/asdf/core/ndarray-1.0.0"
+  unit:
+    description: |
+      The unit corresponding to the values
+    $ref: "http://stsci.edu/schemas/asdf/unit/unit-1.0.0"
+  wrap_angle:
+    description: |
+      Angle at which to wrap back to ``wrap_angle - 360 deg``.
+    $ref: "angle-1.0.0"
+
+required: [value, unit, wrap_angle]
+...

--- a/asdf_astropy/resources/schemas/coordinates/representation-1.0.0.yaml
+++ b/asdf_astropy/resources/schemas/coordinates/representation-1.0.0.yaml
@@ -1,0 +1,207 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/representation-1.0.0"
+tag: "tag:astropy.org:astropy/coordinates/representation-1.0.0"
+
+title: |
+  Representation of points or differentials in two or three dimensional space.
+
+description: |
+  Representation of points or differentials in two or three dimensional space.
+
+examples:
+  -
+    - A SphericalRepresentation
+    - |
+        !<tag:astropy.org:astropy/coordinates/representation-1.0.0>
+          components:
+            distance: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 AU, value: 1.0}
+            lat: !<tag:astropy.org:astropy/coordinates/latitude-1.0.0> {unit: !unit/unit-1.0.0 deg,
+              value: 10.0}
+            lon: !<tag:astropy.org:astropy/coordinates/longitude-1.0.0>
+              unit: !unit/unit-1.0.0 deg
+              value: 10.0
+              wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.0.0> {unit: !unit/unit-1.0.0 deg,
+                value: 360.0}
+          type: SphericalRepresentation
+  -
+    - A CartesianDifferential
+    - |
+        !<tag:astropy.org:astropy/coordinates/representation-1.0.0>
+          components:
+            d_x: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 km s-1, value: 100.0}
+            d_y: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 km s-1, value: 200.0}
+            d_z: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 km s-1, value: 3141.0}
+          type: CartesianDifferential
+
+type: object
+properties:
+  type:
+    type: string
+    enum:
+      - CartesianRepresentation
+      - SphericalRepresentation
+      - UnitSphericalRepresentation
+      - RadialRepresentation
+      - PhysicsSphericalRepresentation
+      - CylindricalRepresentation
+      - CartesianDifferential
+      - SphericalDifferential
+      - UnitSphericalCosLatDifferential
+      - UnitSphericalDifferential
+      - SphericalCosLatDifferential
+      - RadialDifferential
+      - PhysicsSphericalDifferential
+      - CylindricalDifferential
+
+  components:
+    anyOf:
+      # CartesianRepresentation
+      - type: object
+        properties:
+          x:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+          y:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+          z:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+
+      # SphericalRepresentation
+      - type: object
+        properties:
+          lat:
+            $ref: "latitude-1.0.0"
+          lon:
+            $ref: "longitude-1.0.0"
+          distance:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+
+      # UnitSphericalRepresentation
+      - type: object
+        properties:
+          lat:
+            $ref: "latitude-1.0.0"
+          lon:
+            $ref: "longitude-1.0.0"
+
+      # RadialRepresentation
+      - type: object
+        properties:
+          distance:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+
+      # PhysicsSphericalRepresentation
+      - type: object
+        properties:
+          phi:
+            $ref: "angle-1.0.0"
+          theta:
+            $ref: "angle-1.0.0"
+          r:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+
+      # CylindricalRepresentation
+      - type: object
+        properties:
+          rho:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+          phi:
+            $ref: "angle-1.0.0"
+          z:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+
+      # CartesianDifferential
+      - type: object
+        properties:
+          d_x:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+          d_y:
+            $ref: "thttp://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+          d_z:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+
+      # SphericalDifferential
+      - type: object
+        properties:
+          d_lon:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+          d_lat:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+          d_distance:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+
+      # UnitSphericalCosLatDifferential
+      - type: object
+        properties:
+          d_lon_coslat:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+          d_lat:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+
+      # UnitSphericalDifferential
+      - type: object
+        properties:
+          d_lon:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+          d_lat:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+
+      # SphericalCosLatDifferential
+      - type: object
+        properties:
+          d_lon_coslat:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+          d_lat:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+          d_distance:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+
+      # SphericalDifferential
+      - type: object
+        properties:
+          d_lon:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+          d_lat:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+          d_distance:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+
+      # RadialDifferential
+      - type: object
+        properties:
+          d_phi:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+          d_theta:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+          d_r:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+
+      # PhysicsSphericalDifferential
+      - type: object
+        properties:
+          d_phi:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+          d_theta:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+          d_r:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+
+      # RadialDifferential
+      - type: object
+        properties:
+          d_distance:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+
+      # CylindricalDifferential
+      - type: object
+        properties:
+          d_rho:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+          d_phi:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+          d_z:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+
+required: [type, components]
+...

--- a/asdf_astropy/resources/schemas/coordinates/skycoord-1.0.0.yaml
+++ b/asdf_astropy/resources/schemas/coordinates/skycoord-1.0.0.yaml
@@ -1,0 +1,20 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/skycoord-1.0.0"
+tag: "tag:astropy.org:astropy/coordinates/skycoord-1.0.0"
+
+title: |
+  Represents a SkyCoord object from astropy
+
+allOf:
+  - type: object
+    properties:
+      frame:
+        description: |
+          A string describing the kind of frame that is represented by this
+          SkyCoord object. This value is used when reconstructing SkyCoord.
+        type: string
+required: [frame]
+additionalProperties: true
+...

--- a/asdf_astropy/resources/schemas/coordinates/spectralcoord-1.0.0.yaml
+++ b/asdf_astropy/resources/schemas/coordinates/spectralcoord-1.0.0.yaml
@@ -1,0 +1,31 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/spectralcoord-1.0.0"
+tag: "tag:astropy.org:astropy/coordinates/spectralcoord-1.0.0"
+
+title: >
+  Represents a SpectralCoord object from astropy
+
+type: object
+properties:
+  value:
+    description: |
+      A vector of one or more values
+    anyOf:
+      - type: number
+      - $ref: "http://stsci.edu/schemas/asdf/core/ndarray-1.0.0"
+  unit:
+    description: |
+      The unit corresponding to the values
+    $ref: "http://stsci.edu/schemas/asdf/unit/unit-1.0.0"
+  observer:
+    description: |
+      The observer frame for this coordinate
+    $ref: "http://astropy.org/schemas/astropy/coordinates/frames/baseframe-1.0.0"
+  target:
+    description: |
+      The target frame for this coordinate
+    $ref: "http://astropy.org/schemas/astropy/coordinates/frames/baseframe-1.0.0"
+required: [value, unit]
+...

--- a/asdf_astropy/resources/schemas/fits/fits-1.0.0.yaml
+++ b/asdf_astropy/resources/schemas/fits/fits-1.0.0.yaml
@@ -1,0 +1,89 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/fits/fits-1.0.0"
+title: >
+  A FITS file inside of an ASDF file.
+description: |
+  This schema is useful for distributing ASDF files that can
+  automatically be converted to FITS files by specifying the exact
+  content of the resulting FITS file.
+
+  Not all kinds of data in FITS are directly representable in ASDF.
+  For example, applying an offset and scale to the data using the
+  `BZERO` and `BSCALE` keywords.  In these cases, it will not be
+  possible to store the data in the native format from FITS and also
+  be accessible in its proper form in the ASDF file.
+
+  Only image and binary table extensions are supported.
+
+examples:
+  -
+    - A simple FITS file with a primary header and two extensions
+    - |
+        !<tag:astropy.org:astropy/fits/fits-1.0.0>
+            - header:
+              - [SIMPLE, true, conforms to FITS standard]
+              - [BITPIX, 8, array data type]
+              - [NAXIS, 0, number of array dimensions]
+              - [EXTEND, true]
+              - []
+              - ['', Top Level MIRI Metadata]
+              - []
+              - [DATE, '2013-08-30T10:49:55.070373', The date this file was created (UTC)]
+              - [FILENAME, MiriDarkReferenceModel_test.fits, The name of the file]
+              - [TELESCOP, JWST, The telescope used to acquire the data]
+              - []
+              - ['', Information about the observation]
+              - []
+              - [DATE-OBS, '2013-08-30T10:49:55.000000', The date the observation was made (UTC)]
+            - data: !core/ndarray-1.0.0
+                datatype: float32
+                shape: [2, 3, 3, 4]
+                source: 0
+                byteorder: big
+              header:
+              - [XTENSION, IMAGE, Image extension]
+              - [BITPIX, -32, array data type]
+              - [NAXIS, 4, number of array dimensions]
+              - [NAXIS1, 4]
+              - [NAXIS2, 3]
+              - [NAXIS3, 3]
+              - [NAXIS4, 2]
+              - [PCOUNT, 0, number of parameters]
+              - [GCOUNT, 1, number of groups]
+              - [EXTNAME, SCI, extension name]
+              - [BUNIT, DN, Units of the data array]
+            - data: !core/ndarray-1.0.0
+                datatype: float32
+                shape: [2, 3, 3, 4]
+                source: 1
+                byteorder: big
+              header:
+              - [XTENSION, IMAGE, Image extension]
+              - [BITPIX, -32, array data type]
+              - [NAXIS, 4, number of array dimensions]
+              - [NAXIS1, 4]
+              - [NAXIS2, 3]
+              - [NAXIS3, 3]
+              - [NAXIS4, 2]
+              - [PCOUNT, 0, number of parameters]
+              - [GCOUNT, 1, number of groups]
+              - [EXTNAME, ERR, extension name]
+              - [BUNIT, DN, Units of the error array]
+
+allOf:
+  - tag: "tag:astropy.org:astropy/fits/fits-1.0.0"
+  - type: array
+    items:
+      type: object
+      properties:
+        data:
+          description: "The data part of the HDU."
+          anyOf:
+            - $ref: "http://stsci.edu/schemas/asdf/core/ndarray-1.0.0"
+            - $ref: "../table/table-1.0.0"
+            # Retain backwards compatibility with table defined by ASDF Standard
+            - $ref: "http://stsci.edu/schemas/asdf/core/table-1.0.0"
+            - type: "null"
+          default: null

--- a/asdf_astropy/resources/schemas/table/table-1.0.0.yaml
+++ b/asdf_astropy/resources/schemas/table/table-1.0.0.yaml
@@ -1,0 +1,130 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/table/table-1.0.0"
+tag: "tag:astropy.org:astropy/table/table-1.0.0"
+
+title: >
+  A table.
+
+description: |
+  A table is represented as a list of columns, where each entry is a
+  [column](ref:http://stsci.edu/schemas/asdf/core/column-1.0.0)
+  object, containing the data and some additional information.
+
+  The data itself may be stored inline as text, or in binary in either
+  row- or column-major order by use of the `strides` property on the
+  individual column arrays.
+
+  Each column in the table must have the same first (slowest moving)
+  dimension.
+
+examples:
+  -
+    - A table stored in column-major order, with each column in a separate block
+    - |
+        !<tag:astropy.org:astropy/table/table-1.0.0>
+          columns:
+          - !core/column-1.0.0
+            data: !core/ndarray-1.0.0
+              source: 0
+              datatype: float64
+              byteorder: little
+              shape: [3]
+            description: RA
+            meta: {foo: bar}
+            name: a
+            unit: !unit/unit-1.0.0 deg
+          - !core/column-1.0.0
+            data: !core/ndarray-1.0.0
+              source: 1
+              datatype: float64
+              byteorder: little
+              shape: [3]
+            description: DEC
+            name: b
+          - !core/column-1.0.0
+            data: !core/ndarray-1.0.0
+              source: 2
+              datatype: [ascii, 1]
+              byteorder: big
+              shape: [3]
+            description: The target name
+            name: c
+          colnames: [a, b, c]
+
+  -
+    - A table stored in row-major order, all stored in the same block
+    - |
+        !<tag:astropy.org:astropy/table/table-1.0.0>
+          columns:
+          - !core/column-1.0.0
+            data: !core/ndarray-1.0.0
+              source: 0
+              datatype: float64
+              byteorder: little
+              shape: [3]
+              strides: [13]
+            description: RA
+            meta: {foo: bar}
+            name: a
+            unit: !unit/unit-1.0.0 deg
+          - !core/column-1.0.0
+            data: !core/ndarray-1.0.0
+              source: 0
+              datatype: float64
+              byteorder: little
+              shape: [3]
+              offset: 4
+              strides: [13]
+            description: DEC
+            name: b
+          - !core/column-1.0.0
+            data: !core/ndarray-1.0.0
+              source: 0
+              datatype: [ascii, 1]
+              byteorder: big
+              shape: [3]
+              offset: 12
+              strides: [13]
+            description: The target name
+            name: c
+          colnames: [a, b, c]
+
+type: object
+properties:
+  columns:
+    description: |
+      A list of columns in the table.
+    type: array
+    items:
+      anyOf:
+        - $ref: "http://stsci.edu/schemas/asdf/core/column-1.0.0"
+        - $ref: "http://stsci.edu/schemas/asdf/core/ndarray-1.0.0"
+        - $ref: "http://stsci.edu/schemas/asdf/time/time-1.1.0"
+        - $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+        - $ref: "../coordinates/skycoord-1.0.0"
+        - $ref: "../coordinates/earthlocation-1.0.0"
+        - $ref: "../time/timedelta-1.0.0"
+
+  colnames:
+    description: |
+      A list containing the names of the columns in the table (in order).
+    type: array
+    items:
+      - type: string
+
+  qtable:
+    description: |
+      A flag indicating whether or not the serialized type was a QTable
+    type: boolean
+    default: False
+
+  meta:
+    description: |
+      Additional free-form metadata about the table.
+    type: object
+    default: {}
+
+additionalProperties: false
+required: [columns, colnames]

--- a/asdf_astropy/resources/schemas/time/timedelta-1.0.0.yaml
+++ b/asdf_astropy/resources/schemas/time/timedelta-1.0.0.yaml
@@ -1,0 +1,34 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/asdf/asdf-schema-1.0.0"
+id: "http://astropy.org/schemas/astropy/time/timedelta-1.0.0"
+title: Represents an instance of TimeDelta from astropy
+description: |
+  Represents the time difference between two times.
+
+type: object
+properties:
+    jd1:
+      anyOf:
+        - type: number
+        - $ref: "http://stsci.edu/schemas/asdf/core/ndarray-1.0.0"
+      description: |
+        Value representing first 64 bits of precision
+    jd2:
+      anyOf:
+        - type: number
+        - $ref: "http://stsci.edu/schemas/asdf/core/ndarray-1.0.0"
+      description: |
+        Value representing second 64 bits of precision
+    format:
+      type: string
+      description: |
+        Format of time value representation.
+    scale:
+      type: string
+      description: |
+        Time scale of input value(s).
+      enum: [tdb, tt, ut1, tcg, tcb, tai, local]
+required: [jd1, jd2, format]
+additionalProperties: False
+...

--- a/asdf_astropy/resources/schemas/transform/units_mapping-1.0.0.yaml
+++ b/asdf_astropy/resources/schemas/transform/units_mapping-1.0.0.yaml
@@ -1,0 +1,99 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/transform/units_mapping-1.0.0"
+tag: "tag:astropy.org:astropy/transform/units_mapping-1.0.0"
+
+title: |
+  Mapper that operates on the units of the input.
+
+description: |
+  This transform operates on the units of the input, first converting to
+  the expected input units, then assigning replacement output units without
+  further conversion.
+
+examples:
+  -
+    - Assign units of seconds to dimensionless input.
+    - |
+      !<tag:astropy.org:astropy/transform/units_mapping-1.0.0>
+        inputs:
+          - name: x
+            unit: !unit/unit-1.0.0
+        outputs:
+          - name: x
+            unit: !unit/unit-1.0.0 s
+  -
+    - Convert input to meters, then assign dimensionless units.
+    - |
+      !<tag:astropy.org:astropy/transform/units_mapping-1.0.0>
+        inputs:
+          - name: x
+            unit: !unit/unit-1.0.0 m
+        outputs:
+          - name: x
+            unit: !unit/unit-1.0.0
+
+  -
+    - Convert input to meters, then drop units entirely.
+    - |
+      !<tag:astropy.org:astropy/transform/units_mapping-1.0.0>
+        inputs:
+          - name: x
+            unit: !unit/unit-1.0.0 m
+        outputs:
+          - name: x
+
+  -
+    - Accept any units, then replace with meters.
+    - |
+      !<tag:astropy.org:astropy/transform/units_mapping-1.0.0>
+        inputs:
+          - name: x
+        outputs:
+          - name: x
+            unit: !unit/unit-1.0.0 m
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.2.0"
+  - type: object
+    properties:
+      inputs:
+        description: |
+          Array of input configurations.
+        type: array
+        items:
+          $ref: "#/definitions/value_configuration"
+      outputs:
+        description: |
+          Array of output configurations.
+        type: array
+        items:
+          $ref: "#/definitions/value_configuration"
+    required: [inputs, outputs]
+
+definitions:
+  value_configuration:
+    description: |
+      Configuration of a single model value (input or output).
+    type: object
+    properties:
+      name:
+        description: |
+          Value name.
+        type: string
+      unit:
+        description: |
+          Expected unit.
+        $ref: "http://stsci.edu/schemas/asdf/unit/unit-1.0.0"
+      equivalencies:
+        description: |
+          Equivalencies to apply when converting value to expected unit.
+        $ref: "http://astropy.org/schemas/astropy/units/equivalency-1.0.0"
+      allow_dimensionless:
+        description: |
+          Allow this value to receive dimensionless data.
+        type: boolean
+        default: false
+    required: [name]
+...

--- a/asdf_astropy/resources/schemas/units/equivalency-1.0.0.yaml
+++ b/asdf_astropy/resources/schemas/units/equivalency-1.0.0.yaml
@@ -1,0 +1,35 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/units/equivalency-1.0.0"
+tag: "tag:astropy.org:astropy/units/equivalency-1.0.0"
+
+title: |
+  Represents unit equivalency.
+
+description: |
+  Supports serialization of equivalencies between units
+  in certain contexts
+
+definitions:
+  equivalency:
+    type: object
+    properties:
+      name:
+        type: string
+      kwargs_names:
+        type: array
+        items:
+          type: string
+      kwargs_values:
+        type: array
+        items:
+          anyOf:
+            - $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+            - type: number
+            - type: "null"
+
+type: array
+items:
+  $ref: "#/definitions/equivalency"
+...

--- a/asdf_astropy/tests/test_integration.py
+++ b/asdf_astropy/tests/test_integration.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+import yaml
+import asdf
+
+
+def test_resources():
+    resources_root = Path(__file__).parent.parent / "resources"
+    resource_manager = asdf.get_config().resource_manager
+
+    for resource_path in resources_root.glob("**/*.yaml"):
+        with resource_path.open("rb") as f:
+            resource_content = f.read()
+        resource = yaml.safe_load(resource_content)
+        resource_uri = resource["id"]
+        assert resource_manager[resource_uri] == resource_content
+
+
+def test_manifests():
+    manifests_root = (
+        Path(__file__).parent.parent / "resources" / "manifests"
+    )
+    resource_manager = asdf.get_config().resource_manager
+
+    for manifest_path in manifests_root.glob("*.yaml"):
+        with manifest_path.open("rb") as f:
+            manifest_content = f.read()
+        manifest = yaml.safe_load(manifest_content)
+
+        manifest_schema = asdf.schema.load_schema(
+            "asdf://asdf-format.org/core/schemas/extension_manifest-1.0"
+        )
+
+        # The manifest must be valid against its own schema:
+        asdf.schema.validate(manifest, schema=manifest_schema)
+
+        for tag_definition in manifest["tags"]:
+            # The tag's schema must be available:
+            assert tag_definition["schema_uri"] in resource_manager

--- a/scripts/generate_manifest.py
+++ b/scripts/generate_manifest.py
@@ -1,0 +1,64 @@
+"""
+Script that creates initial astropy manifest from the schemas
+in the resources directory.  This file can be removed once
+the format of the manifest files has been finalized.
+"""
+import argparse
+from pathlib import Path
+
+import yaml
+import asdf
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("schemas_path")
+    parser.add_argument("output_path")
+    return parser.parse_args()
+
+
+class MultilineString(str):
+    pass
+
+
+def represent_multiline_string(dumper, data):
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+
+
+yaml.add_representer(MultilineString, represent_multiline_string)
+
+args = parse_args()
+
+manifest = {}
+
+manifest["id"] = "http://astropy.org/asdf/extensions/astropy/manifests/astropy-1.0"
+manifest["extension_uri"] = "http://astropy.org/asdf/extensions/astropy-1.0"
+manifest["title"] = f"Astropy extension 1.0"
+manifest["description"] = MultilineString(
+    "A set of tags for serializing astropy objects.  This does not include most\n"
+    "model classes, which are handled by an implementation of the ASDF\n"
+    "transform extension."
+)
+manifest["asdf_standard_requirement"] = {
+    "gte": "1.1.0",
+}
+manifest["tags"] = []
+
+for schema_path in Path(args.schemas_path).glob("**/*.yaml"):
+    schema = yaml.safe_load(schema_path.read_bytes())
+    tag_def = {
+        "tag_uri": schema["id"].replace("http://astropy.org/schemas/astropy/", "tag:astropy.org:astropy/"),
+        "schema_uri": schema["id"],
+        "title": schema["title"].strip(),
+    }
+
+    if "tag" in schema:
+        assert tag_def["tag_uri"] == schema["tag"]
+
+    if "description" in schema:
+        tag_def["description"] = MultilineString(schema["description"].strip())
+
+    manifest["tags"].append(tag_def)
+
+with open(args.output_path, "w") as f:
+    yaml.dump(manifest, f, sort_keys=False)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,10 @@
 [metadata]
 name = asdf_astropy
 author = The ASDF dev team
-author_email =
+author_email = astropy.team@gmail.com
 license = BSD 3-Clause
 license_file = licenses/LICENSE.rst
-url = http://docs/astropy.org/projects/asdf-astropy
+url = http://docs.astropy.org/projects/asdf-astropy
 description = Astropy Converters for ASDF
 long_description = file: README.rst
 long_description_content_type = text/x-rst
@@ -12,19 +12,22 @@ edit_on_github = False
 github_project = astropy/asdf-astropy
 
 [options]
-zip_safe = False
+zip_safe = True
 packages = find:
 python_requires = >=3.6
 setup_requires = setuptools_scm
 install_requires =
     astropy @ git+https://github.com/astropy/astropy#egg=astropy
-    asdf @ git+https://github.com/asdf-format/asdf@asdf-standard-2.0.0-epic
+    asdf @ git+https://github.com/asdf-format/asdf
     numpy
     asdf-transform-schemas @ git+https://github.com/asdf-format/asdf-transform-schemas#egg=asdf_transform_schemas
+    importlib_resources>=3;python_version<"3.9"
 
 [options.entry_points]
 asdf.converter_providers =
   asdf-astropy = asdf_astropy.extension:TransformConverterProvider
+asdf.resource_mappings =
+  asdf-astropy = asdf_astropy.integration:get_resource_mappings
 
 [options.extras_require]
 test =
@@ -33,7 +36,7 @@ docs =
     sphinx-astropy
 
 [options.package_data]
-asdf-astropy = data/*
+asdf_astropy.resources = manifests/*.yaml, schemas/*.yaml, schemas/**/*.yaml, schemas/**/**/*.yaml
 
 [tool:pytest]
 testpaths = "asdf-astropy" "docs"


### PR DESCRIPTION
This PR adds the astropy schemas to this repo, a manifest file for their associated tags, and a plugin for accessing them from asdf.

The schemas are mostly unchanged, but I did make two fixes:

- Renamed time-1.0.0 to timedelta-1.0.0 to match its tag
- Updated `$ref` properties containing tags to be schema ids instead

Tests will not pass with the prototype converters still in place, but that'll get fixed in the next PR.