### PR TITLE
MNT: Replace master with main

### DIFF
--- a/.github/workflows/asdf_astropy_ci.yml
+++ b/.github/workflows/asdf_astropy_ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - "*"
   pull_request:

--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,8 @@ Astropy Converters for ASDF
     :target: https://github.com/astropy/asdf-astropy/actions
     :alt: CI Status
 	  
-.. image:: https://codecov.io/gh/astropy/asdf-astropy/branch/master/graph/badge.svg
-    :target: https://codecov.io/gh/astropy/asdf-astropy/branch=master
+.. image:: https://codecov.io/gh/astropy/asdf-astropy/branch/main/graph/badge.svg
+    :target: https://codecov.io/gh/astropy/asdf-astropy/branch=main
     :alt: Code coverage
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -168,7 +168,7 @@ man_pages = [('index', project.lower(), project + u' Documentation',
 #
 #
 #     edit_on_github_project = setup_cfg['github_project']
-#     edit_on_github_branch = "master"
+#     edit_on_github_branch = "main"
 #
 #     edit_on_github_source_root = ""
 #     edit_on_github_doc_root = "docs"


### PR DESCRIPTION
This PR attempts to replace all mention of `master` to `main` in this repository. This should be reviewed and merged right after the maintainer has renamed the default branch.

This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.

This is part of #12 