### PR TITLE
Replace master with main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - "*"
   pull_request:
@@ -14,12 +14,12 @@ on:
 
 jobs:
   tox_pytest:
-    name: ${{ matrix.name }} 
+    name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        include: 
+        include:
           - name: Python 3.8 with code coverage
             python-version: "3.8"
             os: ubuntu-latest

--- a/README.rst
+++ b/README.rst
@@ -4,9 +4,9 @@ Astropy Converters for ASDF
 .. image:: https://github.com/astropy/asdf-astropy/workflows/CI/badge.svg
     :target: https://github.com/astropy/asdf-astropy/actions
     :alt: CI Status
-	  
+
 .. image:: https://codecov.io/gh/astropy/asdf-astropy/branch/master/graph/badge.svg
-    :target: https://codecov.io/gh/astropy/asdf-astropy/branch=master
+    :target: https://codecov.io/gh/astropy/asdf-astropy/branch=main
     :alt: Code coverage
 
 
@@ -30,4 +30,3 @@ Contributing
 
 We love contributions! asdf-astropy is open source,
 built on open source, and we'd love to have you hang out in our community.
-

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -168,7 +168,7 @@ man_pages = [('index', project.lower(), project + u' Documentation',
 #
 #
 #     edit_on_github_project = setup_cfg['github_project']
-#     edit_on_github_branch = "master"
+#     edit_on_github_branch = "main"
 #
 #     edit_on_github_source_root = ""
 #     edit_on_github_doc_root = "docs"


### PR DESCRIPTION
This is a copy of #13, which didn't make it into the commit history of `main` because I renamed the default branch in a goofy way.