### PR TITLE
Add converter support for coordinates tags

### DIFF
--- a/asdf_astropy/converters/coordinates/angle.py
+++ b/asdf_astropy/converters/coordinates/angle.py
@@ -1,0 +1,36 @@
+from ..unit.quantity import QuantityConverter
+
+
+class AngleConverter(QuantityConverter):
+    tags = ["tag:astropy.org:astropy/coordinates/angle-*"]
+
+    types = ["astropy.coordinates.angles.Angle"]
+
+    def from_yaml_tree(self, node, tag, ctx):
+        from astropy.coordinates.angles import Angle
+        return Angle(super().from_yaml_tree(node, tag, ctx))
+
+
+class LatitudeConverter(QuantityConverter):
+    tags = ["tag:astropy.org:astropy/coordinates/latitude-*"]
+
+    types = ["astropy.coordinates.angles.Latitude"]
+
+    def from_yaml_tree(self, node, tag, ctx):
+        from astropy.coordinates.angles import Latitude
+        return Latitude(super().from_yaml_tree(node, tag, ctx))
+
+
+class LongitudeConverter(QuantityConverter):
+    tags = ["tag:astropy.org:astropy/coordinates/longitude-*"]
+
+    types = ["astropy.coordinates.angles.Longitude"]
+
+    def to_yaml_tree(self, obj, tag, ctx):
+        tree = super().to_yaml_tree(obj, tag, ctx)
+        tree["wrap_angle"] = obj.wrap_angle
+        return tree
+
+    def from_yaml_tree(self, node, tag, ctx):
+        from astropy.coordinates.angles import Longitude
+        return Longitude(super().from_yaml_tree(node, tag, ctx), wrap_angle=node["wrap_angle"])

--- a/asdf_astropy/converters/coordinates/earth_location.py
+++ b/asdf_astropy/converters/coordinates/earth_location.py
@@ -1,0 +1,15 @@
+from asdf.extension import Converter
+
+
+class EarthLocationConverter(Converter):
+    tags = ["tag:astropy.org:astropy/coordinates/earthlocation-*"]
+
+    types = ["astropy.coordinates.earth.EarthLocation"]
+
+    def to_yaml_tree(self, obj, tag, ctx):
+        return obj.info._represent_as_dict()
+
+    def from_yaml_tree(self, node, tag, ctx):
+        from astropy.coordinates.earth import EarthLocation
+
+        return EarthLocation.info._construct_from_dict(node)

--- a/asdf_astropy/converters/coordinates/frame.py
+++ b/asdf_astropy/converters/coordinates/frame.py
@@ -1,0 +1,86 @@
+from asdf.extension import Converter
+
+from ..utils import import_type
+
+
+class FrameConverter(Converter):
+    def __init__(self, tag, frame_type_name):
+        self._tag = tag
+        self._frame_type_name = frame_type_name
+        self._frame_type = None
+
+    @property
+    def tags(self):
+        return [self._tag]
+
+    @property
+    def types(self):
+        return [self._frame_type_name]
+
+    @property
+    def frame_type(self):
+        # Delay import until the frame class is needed to improve speed
+        # of loading the extension.
+        if self._frame_type is None:
+            self._frame_type = import_type(self._frame_type_name)
+        return self._frame_type
+
+    def to_yaml_tree(self, obj, tag, ctx):
+        node = {}
+
+        if obj.has_data:
+            node["data"] = obj.data
+
+        # TODO: Figure out why we can't use the frame_attributes
+        # values and document.
+        frame_attributes = {}
+        for attr in obj.frame_attributes.keys():
+            value = getattr(obj, attr, None)
+            if value is not None:
+                frame_attributes[attr] = value
+        node["frame_attributes"] = frame_attributes
+
+        return node
+
+    def from_yaml_tree(self, node, tag, ctx):
+        data = node.get("data", None)
+        if data is not None:
+            return self.frame_type(node["data"], **node["frame_attributes"])
+
+        return self.frame_type(**node["frame_attributes"])
+
+
+class LegacyICRSConverter(Converter):
+    tags = ["tag:astropy.org:astropy/coordinates/frames/icrs-1.0.0"]
+
+    # Leave the types list empty so that the 1.1.0 ICRS converter
+    # is used on write.
+    types = []
+
+    def to_yaml_tree(self, obj, tag, ctx):
+        from astropy.units import Quantity
+
+        return {
+            "ra": {
+                "value": obj.ra.value,
+                "unit": obj.ra.unit.to_string(),
+                "wrap_angle": Quantity(obj.ra.wrap_angle),
+            },
+            "dec": {
+                "value": obj.dec.value,
+                "unit": obj.dec.unit.to_string(),
+            },
+        }
+
+    def from_yaml_tree(self, node, tag, ctx):
+        from astropy.coordinates import Angle, Longitude, Latitude, ICRS
+
+        ra = Longitude(
+            node["ra"]["value"],
+            unit=node["ra"]["unit"],
+            wrap_angle=Angle(node["ra"]["wrap_angle"])
+        )
+
+        dec = Latitude(node["dec"]["value"], unit=node["dec"]["unit"])
+
+        return ICRS(ra=ra, dec=dec)

--- a/asdf_astropy/converters/coordinates/representation.py
+++ b/asdf_astropy/converters/coordinates/representation.py
@@ -1,0 +1,46 @@
+from asdf.extension import Converter
+
+
+class RepresentationConverter(Converter):
+    tags = ["tag:astropy.org:astropy/coordinates/representation-*"]
+
+    types = [
+        "astropy.coordinates.representation.CartesianDifferential",
+        "astropy.coordinates.representation.CartesianRepresentation",
+        "astropy.coordinates.representation.CylindricalDifferential",
+        "astropy.coordinates.representation.CylindricalRepresentation",
+        "astropy.coordinates.representation.PhysicsSphericalDifferential",
+        "astropy.coordinates.representation.PhysicsSphericalRepresentation",
+        "astropy.coordinates.representation.RadialDifferential",
+        "astropy.coordinates.representation.RadialRepresentation",
+        "astropy.coordinates.representation.SphericalCosLatDifferential",
+        "astropy.coordinates.representation.SphericalDifferential",
+        "astropy.coordinates.representation.SphericalRepresentation",
+        "astropy.coordinates.representation.UnitSphericalCosLatDifferential",
+        "astropy.coordinates.representation.UnitSphericalDifferential",
+        "astropy.coordinates.representation.UnitSphericalRepresentation",
+    ]
+
+    def to_yaml_tree(self, obj, tag, ctx):
+        from astropy.coordinates.distances import Distance
+        from astropy.units import Quantity
+
+        components = {}
+        for c in obj.components:
+            value = getattr(obj, "_" + c, None)
+            if isinstance(value, Distance):
+                # No tag exists for Distance, so we need to "cast"
+                # it to a regular ol' Quantity:
+                components[c] = Quantity(value)
+            elif value is not None:
+                components[c] = value
+
+        return {
+            "type": type(obj).__name__,
+            "components": components,
+        }
+
+    def from_yaml_tree(self, node, tag, ctx):
+        from astropy.coordinates import representation
+
+        return getattr(representation, node["type"])(**node["components"])

--- a/asdf_astropy/converters/coordinates/sky_coord.py
+++ b/asdf_astropy/converters/coordinates/sky_coord.py
@@ -1,0 +1,15 @@
+from asdf.extension import Converter
+
+
+class SkyCoordConverter(Converter):
+    tags = ["tag:astropy.org:astropy/coordinates/skycoord-*"]
+
+    types = ["astropy.coordinates.sky_coordinate.SkyCoord"]
+
+    def to_yaml_tree(self, obj, tag, ctx):
+        return obj.info._represent_as_dict()
+
+    def from_yaml_tree(self, node, tag, ctx):
+        from astropy.coordinates.sky_coordinate import SkyCoord
+
+        return SkyCoord.info._construct_from_dict(node)

--- a/asdf_astropy/converters/coordinates/spectral_coord.py
+++ b/asdf_astropy/converters/coordinates/spectral_coord.py
@@ -1,0 +1,39 @@
+
+from asdf.extension import Converter
+from asdf.tags.core.ndarray import NDArrayType
+
+
+class SpectralCoordConverter(Converter):
+    tags = ["tag:astropy.org:astropy/coordinates/spectralcoord-*"]
+
+    types = ["astropy.coordinates.spectral_coordinate.SpectralCoord"]
+
+    def to_yaml_tree(self, obj, tag, ctx):
+        node = {
+            "value": obj.value,
+            "unit": obj.unit,
+        }
+
+        if obj.observer is not None:
+            node["observer"] = obj.observer
+
+        if obj.target is not None:
+            node["target"] = obj.target
+
+        return node
+
+    def from_yaml_tree(self, node, tag, ctx):
+        from astropy.coordinates.spectral_coordinate import SpectralCoord
+
+        value = node["value"]
+        if isinstance(value, NDArrayType):
+            # TODO: Why doesn't NDArrayType work?  This needs some research
+            # and documentation.  See similar note in QuantityConverter.
+            value = value._make_array()
+
+        return SpectralCoord(
+            value,
+            unit=node["unit"],
+            observer=node.get("observer"),
+            target=node.get("target"),
+        )

--- a/asdf_astropy/converters/coordinates/tests/helpers.py
+++ b/asdf_astropy/converters/coordinates/tests/helpers.py
@@ -1,0 +1,42 @@
+from astropy.tests.helper import assert_quantity_allclose
+import astropy.units as u
+import numpy as np
+
+
+def assert_representation_equal(a, b):
+    __tracebackhide__ = True
+
+    assert type(a) is type(b)
+    assert a.components == b.components
+    for component in a.components:
+        assert u.allclose(getattr(a, component), getattr(b, component))
+
+
+def assert_sky_coord_equal(a, b):
+    __tracebackhide__ = True
+
+    assert a.is_equivalent_frame(b)
+    assert a.representation_type is b.representation_type
+    assert a.shape == b.shape
+
+    assert_representation_equal(a.data, b.data)
+
+
+def assert_frame_equal(a, b):
+    __tracebackhide__ = True
+
+    assert type(a) is type(b)
+
+    if a is None:
+        return
+
+    assert_representation_equal(a.data, b.data)
+
+
+def assert_spectral_coord_equal(a, b):
+    __tracebackhide__ = True
+
+    assert type(a) is type(b)
+    assert_quantity_allclose(a.quantity, b.quantity)
+    assert_frame_equal(a.observer, b.observer)
+    assert_frame_equal(a.target, b.target)

--- a/asdf_astropy/converters/coordinates/tests/test_angle.py
+++ b/asdf_astropy/converters/coordinates/tests/test_angle.py
@@ -1,0 +1,38 @@
+import pytest
+
+import asdf
+from astropy import units as u
+from astropy.coordinates import Angle, Latitude, Longitude
+import numpy as np
+
+
+@pytest.fixture(autouse=True)
+def remove_astropy_extensions():
+    """
+    Disable the old astropy extension so that it doesn't
+    confuse our test results.
+    """
+    with asdf.config_context() as config:
+        config.remove_extension(package="astropy")
+        yield
+
+
+TEST_ANGLES = [
+    Angle(100, u.deg),
+    Angle([100, 120, 150], u.deg),
+    Angle([[90, 100, 110], [100, 120, 150]], u.deg),
+    Angle(np.arange(100).reshape(5, 2, 10), u.deg),
+    Latitude(10, u.deg),
+    Longitude(-100, u.deg, wrap_angle=180 * u.deg),
+]
+
+
+@pytest.mark.parametrize("angle", TEST_ANGLES)
+def test_serialization(angle, tmp_path):
+    file_path = tmp_path / "test.asdf"
+    with asdf.AsdfFile() as af:
+        af["angle"] = angle
+        af.write_to(file_path)
+
+    with asdf.open(file_path) as af:
+        assert (af["angle"] == angle).all()

--- a/asdf_astropy/converters/coordinates/tests/test_earth_location.py
+++ b/asdf_astropy/converters/coordinates/tests/test_earth_location.py
@@ -1,0 +1,62 @@
+import pytest
+
+import asdf
+from astropy import units as u
+from astropy.units import Quantity
+from astropy.coordinates import EarthLocation, Longitude, Latitude
+from astropy.coordinates.earth import ELLIPSOIDS
+
+
+@pytest.fixture(autouse=True)
+def remove_astropy_extensions():
+    """
+    Disable the old astropy extension so that it doesn't
+    confuse our test results.
+    """
+    with asdf.config_context() as config:
+        config.remove_extension(package="astropy")
+        yield
+
+
+TEST_LONGITUDE = Longitude([0., 45., 90., 135., 180., -180, -90, -45], u.deg, wrap_angle=180 * u.deg)
+TEST_LATITUDE = Latitude([+0., 30., 60., +90., -90., -60., -30., 0.], u.deg)
+TEST_HEIGHT = Quantity([0.1, 0.5, 1.0, -0.5, -1.0, +4.2, -11., -.1], u.m)
+TEST_POSITION = (TEST_LONGITUDE, TEST_LATITUDE, TEST_HEIGHT)
+
+TEST_EARTH_LOCATIONS = [
+    EarthLocation(lat=34.4900 * u.deg, lon=-104.221800 * u.deg, height=40 * u.km),
+    EarthLocation(*EarthLocation.from_geodetic(*TEST_POSITION).to_geocentric()),
+]
+
+TEST_EARTH_LOCATIONS.extend([EarthLocation.from_geodetic(*TEST_POSITION, ellipsoid=e) for e in ELLIPSOIDS])
+
+
+@pytest.mark.parametrize("earth_location", TEST_EARTH_LOCATIONS)
+def test_serialization(earth_location, tmp_path):
+    file_path = tmp_path / "test.asdf"
+    with asdf.AsdfFile() as af:
+        af["earth_location"] = earth_location
+        af.write_to(file_path)
+
+    with asdf.open(file_path) as af:
+        assert (af["earth_location"] == earth_location).all()
+
+
+@pytest.fixture
+def builtin_site_registry():
+    orig_sites = getattr(EarthLocation, "_site_registry", None)
+    EarthLocation._get_site_registry(force_builtin=True)
+    yield
+    EarthLocation._site_registry = orig_sites
+
+
+def test_earthlocation_site(tmp_path, builtin_site_registry):
+    earth_location = EarthLocation.of_site("greenwich")
+
+    file_path = tmp_path / "test.asdf"
+    with asdf.AsdfFile() as af:
+        af["earth_location"] = earth_location
+        af.write_to(file_path)
+
+    with asdf.open(file_path) as af:
+        assert (af["earth_location"] == earth_location).all()

--- a/asdf_astropy/converters/coordinates/tests/test_frame.py
+++ b/asdf_astropy/converters/coordinates/tests/test_frame.py
@@ -1,0 +1,72 @@
+
+
+import pytest
+
+import asdf
+from astropy import units as u
+from astropy.coordinates import (
+    Angle,
+    CartesianRepresentation,
+    CIRS,
+    FK4,
+    FK4NoETerms,
+    FK5,
+    Galactic,
+    Galactocentric,
+    GCRS,
+    ICRS,
+    ITRS,
+    Latitude,
+    Longitude,
+    PrecessedGeocentric,
+    SphericalRepresentation,
+)
+from astropy.time import Time
+import numpy as np
+
+from .helpers import assert_frame_equal
+
+
+TEST_DATA = {
+    "ra": 1 * u.deg,
+    "dec": 2 * u.deg,
+}
+
+TEST_FRAMES = [
+    CIRS(**TEST_DATA),
+    CIRS(**TEST_DATA, obstime=Time("J2005")),
+    FK4(**TEST_DATA),
+    FK4(**TEST_DATA, obstime=Time("B1950")),
+    FK4NoETerms(**TEST_DATA),
+    FK4NoETerms(**TEST_DATA, obstime= Time("J1975")),
+    FK5(**TEST_DATA),
+    FK5(**TEST_DATA, equinox="J2005"),
+    FK5(**TEST_DATA, equinox="2011-01-01T00:00:00"),
+    Galactic(l=47.37 * u.degree, b=+6.32 * u.degree),
+    Galactocentric(
+        x=np.linspace(-10., 10., 100) * u.kpc,
+        y=np.linspace(-10., 10., 100) * u.kpc,
+        z=np.zeros(100) * u.kpc,
+        z_sun=15 * u.pc
+    ),
+    GCRS(**TEST_DATA),
+    GCRS(**TEST_DATA, obsgeoloc=CartesianRepresentation([1, 2, 3], unit=u.m)),
+    ICRS(**TEST_DATA),
+    ICRS(ra=Longitude(25, unit=u.deg), dec=Latitude(45, unit=u.deg)),
+    ICRS(ra=Longitude(25, unit=u.deg, wrap_angle=Angle(1.5, unit=u.rad)), dec=Latitude(45, unit=u.deg)),
+    ICRS(ra=[0, 1, 2] * u.deg, dec=[3, 4, 5] * u.deg),
+    ITRS(SphericalRepresentation(lon=12.3 * u.deg, lat=45.6 * u.deg, distance=1 * u.km)),
+    PrecessedGeocentric(**TEST_DATA),
+    PrecessedGeocentric(**TEST_DATA, equinox="B1975"),
+]
+
+
+@pytest.mark.parametrize("frame", TEST_FRAMES)
+def test_serialization(frame, tmp_path):
+    file_path = tmp_path / "test.asdf"
+    with asdf.AsdfFile() as af:
+        af["frame"] = frame
+        af.write_to(file_path)
+
+    with asdf.open(file_path) as af:
+        assert_frame_equal(af["frame"], frame)

--- a/asdf_astropy/converters/coordinates/tests/test_representation.py
+++ b/asdf_astropy/converters/coordinates/tests/test_representation.py
@@ -1,0 +1,51 @@
+import pytest
+
+import asdf
+import astropy.units as u
+from astropy.coordinates import Angle, representation
+from numpy.random import random
+
+from .helpers import assert_representation_equal
+
+
+@pytest.fixture(autouse=True)
+def remove_astropy_extensions():
+    """
+    Disable the old astropy extension so that it doesn't
+    confuse our test results.
+    """
+    with asdf.config_context() as config:
+        config.remove_extension(package="astropy")
+        yield
+
+
+REPRESENTATION_CLASSES = [
+    getattr(representation, class_name)
+    for class_name in representation.__all__
+    if "Base" not in class_name
+]
+
+
+def create_representation(rep_class):
+    kwargs = {}
+    for attr_name, attr_type in rep_class.attr_classes.items():
+        if issubclass(attr_type, Angle):
+            value = random((100,)) * u.deg
+        else:
+            value = random((100,)) * u.km
+        kwargs[attr_name] = value
+
+    return rep_class(**kwargs)
+
+
+@pytest.mark.parametrize("rep_class", REPRESENTATION_CLASSES)
+def test_serialization(rep_class, tmp_path):
+    rep = create_representation(rep_class)
+    file_path = tmp_path / "test.asdf"
+
+    with asdf.AsdfFile() as af:
+        af["rep"] = rep
+        af.write_to(file_path)
+
+    with asdf.open(file_path) as af:
+        assert_representation_equal(af["rep"], rep)

--- a/asdf_astropy/converters/coordinates/tests/test_sky_coord.py
+++ b/asdf_astropy/converters/coordinates/tests/test_sky_coord.py
@@ -1,0 +1,78 @@
+import pytest
+
+import asdf
+import astropy.units as u
+from astropy.coordinates import SkyCoord, FK4, Galactic, ICRS, Longitude
+import numpy as np
+
+from .helpers import assert_sky_coord_equal
+
+
+# These are cribbed directly from the Examples section of
+# https://docs.astropy.org/en/stable/api/astropy.coordinates.SkyCoord.html
+TEST_COORDS = [
+    # Defaults to ICRS frame
+    SkyCoord(10, 20, unit="deg"),
+    # Vector of 3 coords
+    SkyCoord([1, 2, 3], [-30, 45, 8], frame="icrs", unit="deg"),
+    # FK4 frame
+    SkyCoord(
+        ["1:12:43.2 +1:12:43", "1 12 43.2 +1 12 43"],
+        frame=FK4,
+        unit=(u.deg, u.hourangle),
+        obstime="J1992.21",
+    ),
+    # Galactic frame
+    SkyCoord("1h12m43.2s +1d12m43s", frame=Galactic),
+    SkyCoord(frame="galactic", l="1h12m43.2s", b="+1d12m43s"),
+    # With ra and dec
+    SkyCoord(
+        Longitude([1, 2, 3], unit=u.deg),
+        np.array([4.5, 5.2, 6.3]) * u.deg,
+        frame="icrs",
+    ),
+    SkyCoord(
+        frame=ICRS,
+        ra=Longitude([1, 2, 3], unit=u.deg),
+        dec=np.array([4.5, 5.2, 6.3]) * u.deg,
+        obstime="2001-01-02T12:34:56"
+    ),
+    # With overridden frame defaults
+    SkyCoord(FK4(1 * u.deg, 2 * u.deg), obstime="J2010.11", equinox="B1965"),
+    # Cartesian
+    SkyCoord(w=0, u=1, v=2, unit="kpc", frame="galactic", representation_type="cartesian"),
+    # Vector frame
+    SkyCoord([ICRS(ra=1 * u.deg, dec=2 * u.deg), ICRS(ra=3 * u.deg, dec=4 * u.deg)]),
+    # 2D obstime
+    SkyCoord([1, 2], [3, 4], [5, 6], unit="deg,deg,m", frame="fk4", obstime=["J1990.5", "J1991.5"]),
+    # Radial velocity
+    SkyCoord(ra=1 * u.deg, dec=2 * u.deg, radial_velocity=10 * u.km / u.s),
+    # Proper motion
+    SkyCoord(ra=1 * u.deg, dec=2 * u.deg, pm_ra_cosdec=2 * u.mas / u.yr, pm_dec=1 * u.mas / u.yr),
+]
+
+
+@pytest.mark.parametrize("coord", TEST_COORDS)
+def test_serialization(coord, tmp_path):
+    file_path = tmp_path / "test.asdf"
+
+    with asdf.AsdfFile() as af:
+        af["coord"] = coord
+        af.write_to(file_path)
+
+    with asdf.open(file_path) as af:
+        assert_sky_coord_equal(af["coord"], coord)
+
+
+def test_serializaton_extra_attribute(tmp_path):
+    coord = SkyCoord(10 * u.deg, 20 * u.deg, equinox="2011-01-01T00:00", frame="fk4").transform_to("icrs")
+
+    file_path = tmp_path / "test.asdf"
+
+    with asdf.AsdfFile() as af:
+        af["coord"] = coord
+        af.write_to(file_path)
+
+    with asdf.open(file_path) as af:
+        assert_sky_coord_equal(af["coord"], coord)
+        assert hasattr(af["coord"], "equinox")

--- a/asdf_astropy/converters/coordinates/tests/test_spectral_coord.py
+++ b/asdf_astropy/converters/coordinates/tests/test_spectral_coord.py
@@ -1,0 +1,60 @@
+import warnings
+
+import pytest
+
+# No spectral_coordinate module in astropy 4.0.x
+pytest.importorskip("astropy.coordinates.spectral_coordinate")
+
+import asdf
+from astropy import units as u
+from astropy.coordinates import SpectralCoord, ICRS, Galactic
+from astropy.coordinates.spectral_coordinate import NoVelocityWarning
+from astropy.tests.helper import assert_quantity_allclose
+
+from .helpers import assert_frame_equal
+
+
+@pytest.fixture(autouse=True)
+def remove_astropy_extensions():
+    """
+    Disable the old astropy extension so that it doesn't
+    confuse our test results.
+    """
+    with asdf.config_context() as config:
+        config.remove_extension(package="astropy")
+        yield
+
+
+TEST_COORDS = [
+    # Scalar
+    SpectralCoord(565 * u.nm),
+    # Vector
+    SpectralCoord([100, 200, 300] * u.GHz),
+]
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", NoVelocityWarning)
+    TEST_COORDS.append(
+        # With observer and target
+        SpectralCoord(
+            10 * u.GHz,
+            observer=ICRS(1 * u.km, 2 * u.km, 3 * u.km, representation_type="cartesian"),
+            target=Galactic(10 * u.deg, 20 * u.deg, distance=30 * u.pc)
+        )
+    )
+
+
+@pytest.mark.filterwarnings("ignore::astropy.coordinates.spectral_coordinate.NoVelocityWarning")
+@pytest.mark.parametrize("coord", TEST_COORDS)
+def test_serialization(coord, tmp_path):
+    file_path = tmp_path / "test.asdf"
+
+    with asdf.AsdfFile() as af:
+        af["coord"] = coord
+        af.write_to(file_path)
+
+    with asdf.open(file_path) as af:
+        assert type(af["coord"]) is type(coord)
+        assert_quantity_allclose(af["coord"].quantity, coord.quantity)
+        assert_frame_equal(af["coord"].observer, coord.observer)
+        assert_frame_equal(af["coord"].target, coord.target)

--- a/asdf_astropy/converters/transform/core.py
+++ b/asdf_astropy/converters/transform/core.py
@@ -1,7 +1,8 @@
-import importlib
 import abc
 
 from asdf.extension import Converter
+
+from ..utils import import_type
 
 
 def parameter_to_value(param):
@@ -23,25 +24,6 @@ def parameter_to_value(param):
         return u.Quantity(param)
     else:
         return param.value
-
-
-def import_type(type_name):
-    """
-    Import a Python type from its fully-qualified name.
-    For example, when this method is called with 'builtins.str'
-    it will return the `str` type.
-
-    Parameters
-    ----------
-    type_name : str
-        Type name, with module.
-
-    Returns
-    -------
-    type
-    """
-    module_name, class_name = type_name.rsplit(".", 1)
-    return getattr(importlib.import_module(module_name), class_name)
 
 
 # One converter, UnitsMappingConverter, does not inherit

--- a/asdf_astropy/converters/utils.py
+++ b/asdf_astropy/converters/utils.py
@@ -1,0 +1,20 @@
+import importlib
+
+
+def import_type(type_name):
+    """
+    Import a Python type from its fully-qualified name.
+    For example, when this method is called with 'builtins.str'
+    it will return the `str` type.
+
+    Parameters
+    ----------
+    type_name : str
+        Type name, with module.
+
+    Returns
+    -------
+    type
+    """
+    module_name, class_name = type_name.rsplit(".", 1)
+    return getattr(importlib.import_module(module_name), class_name)

--- a/asdf_astropy/extensions.py
+++ b/asdf_astropy/extensions.py
@@ -18,6 +18,13 @@ from .converters.unit.equivalency import EquivalencyConverter
 from .converters.unit.quantity import QuantityConverter
 from .converters.unit.unit import UnitConverter
 
+from .converters.coordinates.angle import AngleConverter, LatitudeConverter, LongitudeConverter
+from .converters.coordinates.earth_location import EarthLocationConverter
+from .converters.coordinates.frame import FrameConverter, LegacyICRSConverter
+from .converters.coordinates.representation import RepresentationConverter
+from .converters.coordinates.sky_coord import SkyCoordConverter
+from .converters.coordinates.spectral_coord import SpectralCoordConverter
+
 
 TRANSFORM_CONVERTERS = [
     # astropy.modeling.core
@@ -373,6 +380,54 @@ TRANSFORM_EXTENSIONS = [
 ASTROPY_CONVERTERS = [
     EquivalencyConverter(),
     UnitsMappingConverter(),
+    AngleConverter(),
+    LatitudeConverter(),
+    LongitudeConverter(),
+    EarthLocationConverter(),
+    FrameConverter(
+        "tag:astropy.org:astropy/coordinates/frames/cirs-*",
+        "astropy.coordinates.builtin_frames.cirs.CIRS",
+    ),
+    FrameConverter(
+        "tag:astropy.org:astropy/coordinates/frames/fk4-*",
+        "astropy.coordinates.builtin_frames.fk4.FK4",
+    ),
+    FrameConverter(
+        "tag:astropy.org:astropy/coordinates/frames/fk4noeterms-*",
+        "astropy.coordinates.builtin_frames.fk4.FK4NoETerms",
+    ),
+    FrameConverter(
+        "tag:astropy.org:astropy/coordinates/frames/fk5-*",
+        "astropy.coordinates.builtin_frames.fk5.FK5",
+    ),
+    FrameConverter(
+        "tag:astropy.org:astropy/coordinates/frames/galactic-*",
+        "astropy.coordinates.builtin_frames.galactic.Galactic",
+    ),
+    FrameConverter(
+        "tag:astropy.org:astropy/coordinates/frames/galactocentric-*",
+        "astropy.coordinates.builtin_frames.galactocentric.Galactocentric",
+    ),
+    FrameConverter(
+        "tag:astropy.org:astropy/coordinates/frames/gcrs-*",
+        "astropy.coordinates.builtin_frames.gcrs.GCRS",
+    ),
+    FrameConverter(
+        "tag:astropy.org:astropy/coordinates/frames/icrs-1.1.0",
+        "astropy.coordinates.builtin_frames.icrs.ICRS",
+    ),
+    FrameConverter(
+        "tag:astropy.org:astropy/coordinates/frames/itrs-*",
+        "astropy.coordinates.builtin_frames.itrs.ITRS",
+    ),
+    FrameConverter(
+        "tag:astropy.org:astropy/coordinates/frames/precessedgeocentric-*",
+        "astropy.coordinates.builtin_frames.gcrs.PrecessedGeocentric",
+    ),
+    LegacyICRSConverter(),
+    RepresentationConverter(),
+    SkyCoordConverter(),
+    SpectralCoordConverter(),
 ]
 
 

--- a/asdf_astropy/resources/manifests/astropy-1.0.0.yaml
+++ b/asdf_astropy/resources/manifests/astropy-1.0.0.yaml
@@ -45,6 +45,9 @@ tags:
 - tag_uri: tag:astropy.org:astropy/coordinates/frames/itrs-1.0.0
   schema_uri: http://astropy.org/schemas/astropy/coordinates/frames/itrs-1.0.0
   title: Represents a ITRS coordinate object from astropy
+- tag_uri: tag:astropy.org:astropy/coordinates/frames/icrs-1.0.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/frames/icrs-1.0.0
+  title: Represents an ICRS coordinate object from astropy (deprecated format).
 - tag_uri: tag:astropy.org:astropy/coordinates/frames/icrs-1.1.0
   schema_uri: http://astropy.org/schemas/astropy/coordinates/frames/icrs-1.1.0
   title: Represents an ICRS coordinate object from astropy.

--- a/tox.ini
+++ b/tox.ini
@@ -77,4 +77,4 @@ commands = flake8 asdf_astropy --count --max-line-length=110 --select=E101,W191,
 deps=
     bandit
 commands=
-    bandit asdf_astropy -r -x asdf_astropy/tests,asdf_astropy/converters/transform/tests,asdf_astropy/converters/unit/tests
+    bandit asdf_astropy -r -x asdf_astropy/tests,asdf_astropy/converters/transform/tests,asdf_astropy/converters/unit/tests,asdf_astropy/converters/coordinates/tests


### PR DESCRIPTION
This PR adds converter support for the following tags:

```
tag:astropy.org:astropy/coordinates/angle-1.0.0
tag:astropy.org:astropy/coordinates/latitude-1.0.0
tag:astropy.org:astropy/coordinates/longitude-1.0.0
tag:astropy.org:astropy/coordinates/earthlocation-1.0.0
tag:astropy.org:astropy/coordinates/frames/cirs-1.0.0
tag:astropy.org:astropy/coordinates/frames/fk4-1.0.0
tag:astropy.org:astropy/coordinates/frames/fk4noeterms-1.0.0
tag:astropy.org:astropy/coordinates/frames/fk5-1.0.0
tag:astropy.org:astropy/coordinates/frames/galactic-1.0.0
tag:astropy.org:astropy/coordinates/frames/galactocentric-1.0.0
tag:astropy.org:astropy/coordinates/frames/gcrs-1.0.0
tag:astropy.org:astropy/coordinates/frames/icrs-1.0.0
tag:astropy.org:astropy/coordinates/frames/icrs-1.1.0
tag:astropy.org:astropy/coordinates/frames/itrs-1.0.0
tag:astropy.org:astropy/coordinates/frames/precessedgeocentric-1.0.0
tag:astropy.org:astropy/coordinates/representation-1.0.0
tag:astropy.org:astropy/coordinates/skycoord-1.0.0
tag:astropy.org:astropy/coordinates/spectralcoord-1.0.0
```