### PR TITLE
Use release version of asdf-transform-schemas

### DIFF
--- a/asdf_astropy/converters/transform/tests/test_transform.py
+++ b/asdf_astropy/converters/transform/tests/test_transform.py
@@ -402,6 +402,16 @@ def test_all_models_supported():
         assert len(missing) == 0, message
 
 
+@pytest.mark.xfail(reason="Older tag versions are difficult to test until asdf implements new config features")
+def test_legacy_const(tmpdir):
+    model = astropy_models.Const1D(amplitude=5.)
+    assert_model_roundtrip(model, tmpdir, version="1.3.0")
+
+    model = astropy_models.Const2D(amplitude=5.)
+    with pytest.raises(TypeError, match="does not support models with > 1 dimension"):
+        assert_model_roundtrip(model, tmpdir, version="1.3.0")
+
+
 COMPOUND_LEFT_MODEL = astropy_models.Shift(5)
 COMPOUND_RIGHT_MODEL = astropy_models.Shift(-1)
 COMPOUND_MODELS = [

--- a/asdf_astropy/converters/transform/tests/test_transform.py
+++ b/asdf_astropy/converters/transform/tests/test_transform.py
@@ -402,15 +402,6 @@ def test_all_models_supported():
         assert len(missing) == 0, message
 
 
-def test_legacy_const(tmpdir):
-    model = astropy_models.Const1D(amplitude=5.)
-    assert_model_roundtrip(model, tmpdir, version="1.3.0")
-
-    model = astropy_models.Const2D(amplitude=5.)
-    with pytest.raises(TypeError, match="does not support models with > 1 dimension"):
-        assert_model_roundtrip(model, tmpdir, version="1.3.0")
-
-
 COMPOUND_LEFT_MODEL = astropy_models.Shift(5)
 COMPOUND_RIGHT_MODEL = astropy_models.Shift(-1)
 COMPOUND_MODELS = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ install_requires =
     astropy
     asdf>=2.8.0
     numpy
-    asdf-transform-schemas @ git+https://github.com/asdf-format/asdf-transform-schemas
+    asdf-transform-schemas
     importlib_resources>=3;python_version<"3.9"
     packaging>=16.0
 


### PR DESCRIPTION
The asdf-transform-schemas package has been released, so we no longer need to install it from GitHub.  I'm also removing a test that has been made irrelevant by the change to asdf-transform-schemas to remove the ASDF Standard version requirements.