### PR TITLE
Fix bug in table deserializer when meta is absent from the ASDF

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+0.1.2 (unreleased)
+------------------
+
+- Fix bug in Table deserializer when meta is absent from the ASDF. [#36]
+
 0.1.1 (2021-12-04)
 ------------------
 

--- a/asdf_astropy/converters/table/table.py
+++ b/asdf_astropy/converters/table/table.py
@@ -62,7 +62,7 @@ class AsdfTableConverter(Converter):
     def from_yaml_tree(self, node, tag, ctx):
         from astropy.table import Table
 
-        return Table(node["columns"], meta=node["meta"])
+        return Table(node["columns"], meta=node.get("meta"))
 
 
 class AstropyTableConverter(Converter):


### PR DESCRIPTION
The schema allows meta to be missing, but the Converter implementation assumes that it will be present.  My mistake!