### PR TITLE
Serialization of model unit equivalencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+0.2.0 (unreleased)
+------------------
+
+- Add support for serialization and deserialization of input_units_equivalencies
+  for astropy models. [#37]
+
 0.1.2 (2021-12-14)
 ------------------
 

--- a/asdf_astropy/converters/transform/core.py
+++ b/asdf_astropy/converters/transform/core.py
@@ -116,6 +116,11 @@ class TransformConverterBase(Converter):
             if bounds_nondefaults:
                 node['bounds'] = bounds_nondefaults
 
+        # model input_units_equivalencies
+        if not isinstance(model, CompoundModel):
+            if model.input_units_equivalencies:
+                node['input_units_equivalencies'] = model.input_units_equivalencies
+
         return node
 
     def _serialize_bounding_box(self, model, node):
@@ -170,6 +175,8 @@ class TransformConverterBase(Converter):
                                          if np.isfinite(item[0])] for sbbox in bounding_boxes]
 
     def from_yaml_tree(self, node, tag, ctx):
+        from astropy.modeling.core import CompoundModel
+
         model = self.from_yaml_tree_transform(node, tag, ctx)
 
         if 'name' in node:
@@ -188,6 +195,11 @@ class TransformConverterBase(Converter):
             if constraint in node:
                 param_and_model_constraints[constraint] = node[constraint]
         model._initialize_constraints(param_and_model_constraints)
+
+        if "input_units_equivalencies" in node:
+            # this still writes eqs. for compound, but operates on each sub model
+            if not isinstance(model, CompoundModel):
+                model.input_units_equivalencies = node['input_units_equivalencies']
 
         yield model
 


### PR DESCRIPTION
Allows for `input_unit_equivalencies` to be written and read for models.

Note that, this mirrors the changes in astropy/astropy#10198.