### PR TITLE
Feature/bounding box converters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+0.2.1 (unreleased)
+------------------
+
+- Add converter support for the new ``BoundingBox`` schema and ``CompoundBoundingBox``. [#38]
+
 0.2.0 (2022-03-08)
 ------------------
 

--- a/asdf_astropy/converters/transform/core.py
+++ b/asdf_astropy/converters/transform/core.py
@@ -1,7 +1,5 @@
 import abc
-import warnings
 
-import numpy as np
 from asdf.extension import Converter
 
 from ..utils import import_type
@@ -92,7 +90,6 @@ class TransformConverterBase(Converter):
 
     def to_yaml_tree(self, model, tag, ctx):
         from astropy.modeling.core import CompoundModel
-        from astropy.modeling.bounding_box import ModelBoundingBox
 
         node = self.to_yaml_tree_transform(model, tag, ctx)
 
@@ -109,7 +106,7 @@ class TransformConverterBase(Converter):
 
         # ignore default bounding_box
         if model._user_bounding_box is not None:
-            node['bounding_box'] = model.bounding_box
+            node["bounding_box"] = model.bounding_box
 
         # model / parameter constraints
         if not isinstance(model, CompoundModel):
@@ -135,14 +132,14 @@ class TransformConverterBase(Converter):
         if "name" in node:
             model.name = node["name"]
 
-        if 'inputs' in node:
-            model.inputs = tuple(node['inputs'])
+        if "inputs" in node:
+            model.inputs = tuple(node["inputs"])
 
         if "outputs" in node:
             model.outputs = tuple(node["outputs"])
 
-        if 'bounding_box' in node:
-            model.bounding_box = node['bounding_box']
+        if "bounding_box" in node:
+            model.bounding_box = node["bounding_box"]
 
         param_and_model_constraints = {}
         for constraint in ["fixed", "bounds"]:

--- a/asdf_astropy/converters/transform/core.py
+++ b/asdf_astropy/converters/transform/core.py
@@ -107,20 +107,9 @@ class TransformConverterBase(Converter):
         if getattr(model, "_user_inverse", None) is not None:
             node["inverse"] = model._user_inverse
 
-
-        # Fix 1 deal with default bounding_box
-        try:
-            bbox = model.bounding_box
-            if model._user_bounding_box is None:
-                bbox = ModelBoundingBox.validate(model, model.bounding_box)
-            node['bounding_box'] = bbox
-        except NotImplementedError:
-            pass
-
-        # # Fix 2 ignore default bounding_box
-        # if model._user_bounding_box is not None:
-        #     node['bounding_box'] = model.bounding_box
-
+        # ignore default bounding_box
+        if model._user_bounding_box is not None:
+            node['bounding_box'] = model.bounding_box
 
         # model / parameter constraints
         if not isinstance(model, CompoundModel):

--- a/asdf_astropy/converters/transform/core.py
+++ b/asdf_astropy/converters/transform/core.py
@@ -92,6 +92,7 @@ class TransformConverterBase(Converter):
 
     def to_yaml_tree(self, model, tag, ctx):
         from astropy.modeling.core import CompoundModel
+        from astropy.modeling.bounding_box import ModelBoundingBox
 
         node = self.to_yaml_tree_transform(model, tag, ctx)
 
@@ -107,7 +108,7 @@ class TransformConverterBase(Converter):
             node["inverse"] = model._user_inverse
 
         try:
-            node['bounding_box'] = model.bounding_box
+            node['bounding_box'] = ModelBoundingBox.validate(model, model.bounding_box)
         except NotImplementedError:
             pass
 

--- a/asdf_astropy/converters/transform/core.py
+++ b/asdf_astropy/converters/transform/core.py
@@ -106,7 +106,10 @@ class TransformConverterBase(Converter):
         if getattr(model, "_user_inverse", None) is not None:
             node["inverse"] = model._user_inverse
 
-        self._serialize_bounding_box(model, node)
+        try:
+            node['bounding_box'] = model.bounding_box
+        except NotImplementedError:
+            pass
 
         # model / parameter constraints
         if not isinstance(model, CompoundModel):
@@ -124,58 +127,6 @@ class TransformConverterBase(Converter):
 
         return node
 
-    def _serialize_bounding_box(self, model, node):
-        import astropy
-        from packaging.version import Version
-
-        if Version(astropy.__version__) > Version("4.999.999"):
-            self._serialize_bounding_box_astropy_5(model, node)
-        else:
-            self._serialize_bounding_box_astropy_4(model, node)
-
-    def _serialize_bounding_box_astropy_4(self, model, node):
-        try:
-            bb = model.bounding_box
-        except NotImplementedError:
-            bb = None
-
-        if bb is not None:
-            if model.n_inputs == 1:
-                bb = list(bb)
-            else:
-                bb = [list(item) for item in model.bounding_box]
-            node["bounding_box"] = bb
-
-    def _serialize_bounding_box_astropy_5(self, model, node):
-        from astropy.modeling.bounding_box import CompoundBoundingBox, ModelBoundingBox
-
-        try:
-            bb = model.bounding_box
-        except NotImplementedError:
-            bb = None
-
-        if isinstance(bb, ModelBoundingBox):
-            bb = bb.bounding_box(order="C")
-
-            if model.n_inputs == 1:
-                bb = list(bb)
-            else:
-                bb = [list(item) for item in bb]
-            node["bounding_box"] = bb
-
-        elif isinstance(bb, CompoundBoundingBox):
-            selector_args = [[sa.index, sa.ignore] for sa in bb.selector_args]
-            node["selector_args"] = selector_args
-            node["cbbox_keys"] = list(bb.bounding_boxes.keys())
-
-            bounding_boxes = list(bb.bounding_boxes.values())
-            if len(model.inputs) - len(selector_args) == 1:
-                node["cbbox_values"] = [list(sbbox.bounding_box()) for sbbox in bounding_boxes]
-            else:
-                node["cbbox_values"] = [
-                    [list(item) for item in sbbox.bounding_box() if np.isfinite(item[0])] for sbbox in bounding_boxes
-                ]
-
     def from_yaml_tree(self, node, tag, ctx):
         from astropy.modeling.core import CompoundModel
 
@@ -190,7 +141,8 @@ class TransformConverterBase(Converter):
         if "outputs" in node:
             model.outputs = tuple(node["outputs"])
 
-        self._deserialize_bounding_box(model, node)
+        if 'bounding_box' in node:
+            model.bounding_box = node['bounding_box']
 
         param_and_model_constraints = {}
         for constraint in ["fixed", "bounds"]:
@@ -207,33 +159,6 @@ class TransformConverterBase(Converter):
 
         if "inverse" in node:
             model.inverse = node["inverse"]
-
-    def _deserialize_bounding_box(self, model, node):
-        import astropy
-        from packaging.version import Version
-
-        if Version(astropy.__version__) > Version("4.999.999"):
-            self._deserialize_bounding_box_astropy_5(model, node)
-        else:
-            self._deserialize_bounding_box_astropy_4(model, node)
-
-    def _deserialize_bounding_box_astropy_4(self, model, node):
-        if "bounding_box" in node:
-            model.bounding_box = node["bounding_box"]
-        elif "selector_args" in node:
-            warnings.warn("This version of astropy does not support compound bounding boxes.")
-
-    def _deserialize_bounding_box_astropy_5(self, model, node):
-        from astropy.modeling.bounding_box import CompoundBoundingBox
-
-        if "bounding_box" in node:
-            model.bounding_box = node["bounding_box"]
-        elif "selector_args" in node:
-            cbbox_keys = [tuple(key) for key in node["cbbox_keys"]]
-            bbox_dict = dict(zip(cbbox_keys, node["cbbox_values"]))
-
-            selector_args = node["selector_args"]
-            model.bounding_box = CompoundBoundingBox.validate(model, bbox_dict, selector_args)
 
 
 class SimpleTransformConverter(TransformConverterBase):

--- a/asdf_astropy/converters/transform/core.py
+++ b/asdf_astropy/converters/transform/core.py
@@ -107,10 +107,20 @@ class TransformConverterBase(Converter):
         if getattr(model, "_user_inverse", None) is not None:
             node["inverse"] = model._user_inverse
 
+
+        # Fix 1 deal with default bounding_box
         try:
-            node['bounding_box'] = ModelBoundingBox.validate(model, model.bounding_box)
+            bbox = model.bounding_box
+            if model._user_bounding_box is None:
+                bbox = ModelBoundingBox.validate(model, model.bounding_box)
+            node['bounding_box'] = bbox
         except NotImplementedError:
             pass
+
+        # # Fix 2 ignore default bounding_box
+        # if model._user_bounding_box is not None:
+        #     node['bounding_box'] = model.bounding_box
+
 
         # model / parameter constraints
         if not isinstance(model, CompoundModel):

--- a/asdf_astropy/converters/transform/core.py
+++ b/asdf_astropy/converters/transform/core.py
@@ -184,13 +184,13 @@ class TransformConverterBase(Converter):
         if "name" in node:
             model.name = node["name"]
 
-        self._deserialize_bounding_box(model, node)
-
-        if "inputs" in node:
-            model.inputs = tuple(node["inputs"])
+        if 'inputs' in node:
+            model.inputs = tuple(node['inputs'])
 
         if "outputs" in node:
             model.outputs = tuple(node["outputs"])
+
+        self._deserialize_bounding_box(model, node)
 
         param_and_model_constraints = {}
         for constraint in ["fixed", "bounds"]:

--- a/asdf_astropy/converters/transform/properties.py
+++ b/asdf_astropy/converters/transform/properties.py
@@ -1,0 +1,91 @@
+from asdf.extension import Converter
+
+
+class ModelBoundingBoxConverter(Converter):
+    tags = ["tag:stsci.edu:asdf/transform/property/bounding_box-1.0.0"]
+    types = ["astropy.modeling.bounding_box.ModelBoundingBox"]
+
+    def to_yaml_tree(self, bbox, tag, ctx):
+        from astropy.modeling.bounding_box import ModelBoundingBox
+
+        if isinstance(bbox, ModelBoundingBox):
+            return {
+                'intervals': {
+                    _input: list(interval) for _input, interval in bbox.intervals.items()
+                },
+                'ignore': list(bbox.ignored),
+                'order': bbox.order
+            }
+        else:
+            raise TypeError(f"{bbox} is not a valid ModelBoundingBox!")
+
+    def from_yaml_tree(self, node, tag, ctx):
+        from astropy.modeling.bounding_box import ModelBoundingBox
+
+        intervals = {
+            _input: tuple(interval) for _input, interval in node['intervals'].items()
+        }
+
+        if 'ignore' in node:
+            ignored = node['ignore']
+        else:
+            ignored = None
+
+        if 'order' in node:
+            order = node['order']
+        else:
+            order = 'C'
+
+        return ModelBoundingBox(intervals, ignored=ignored, order=order)
+
+
+class CompoundBoundingBoxConverter(Converter):
+    tags = ["tag:stsci.edu:asdf/transform/property/compound_bounding_box-1.0.0"]
+    types = ["astropy.modeling.bounding_box.CompoundBoundingBox"]
+
+    def to_yaml_tree(self, cbbox, tag, ctx):
+        from astropy.modeling.bounding_box import CompoundBoundingBox
+
+        if isinstance(cbbox, CompoundBoundingBox):
+            return {
+                'selector_args': [
+                    {
+                        'argument': sa[0],
+                        'ignore': sa[1]
+                    } for sa in cbbox.selector_args
+                ],
+                'cbbox': [
+                    {
+                        'key': list(key),
+                        'bbox': bbox
+                    } for key, bbox in cbbox.bounding_boxes.items()
+                ],
+                'ignore': cbbox.global_ignored,
+                'order': cbbox.order
+            }
+        else:
+            raise TypeError(f"{cbbox} is not a valid CompoundBoundingBox!")
+
+    def from_yaml_tree(self, node, tag, ctx):
+        from astropy.modeling.bounding_box import CompoundBoundingBox
+
+        selector_args = tuple([
+            (selector['argument'], selector['ignore']) for selector in node['selector_args']
+        ])
+
+        bounding_boxes = {
+            tuple(bbox['key']): bbox['bbox']
+            for bbox in node['cbbox']
+        }
+
+        if 'ignore' in node:
+            ignored = node['ignore']
+        else:
+            ignored = None
+
+        if 'order' in node:
+            order = node['order']
+        else:
+            order = 'C'
+
+        return CompoundBoundingBox(bounding_boxes, selector_args=selector_args, ignored=ignored, order=order)

--- a/asdf_astropy/converters/transform/properties.py
+++ b/asdf_astropy/converters/transform/properties.py
@@ -10,11 +10,9 @@ class ModelBoundingBoxConverter(Converter):
 
         if isinstance(bbox, ModelBoundingBox):
             return {
-                'intervals': {
-                    _input: list(interval) for _input, interval in bbox.intervals.items()
-                },
-                'ignore': list(bbox.ignored),
-                'order': bbox.order
+                "intervals": {_input: list(interval) for _input, interval in bbox.intervals.items()},
+                "ignore": list(bbox.ignored),
+                "order": bbox.order,
             }
         else:
             raise TypeError(f"{bbox} is not a valid ModelBoundingBox!")
@@ -22,19 +20,17 @@ class ModelBoundingBoxConverter(Converter):
     def from_yaml_tree(self, node, tag, ctx):
         from astropy.modeling.bounding_box import ModelBoundingBox
 
-        intervals = {
-            _input: tuple(interval) for _input, interval in node['intervals'].items()
-        }
+        intervals = {_input: tuple(interval) for _input, interval in node["intervals"].items()}
 
-        if 'ignore' in node:
-            ignored = node['ignore']
+        if "ignore" in node:
+            ignored = node["ignore"]
         else:
             ignored = None
 
-        if 'order' in node:
-            order = node['order']
+        if "order" in node:
+            order = node["order"]
         else:
-            order = 'C'
+            order = "C"
 
         return ModelBoundingBox(intervals, ignored=ignored, order=order)
 
@@ -48,20 +44,10 @@ class CompoundBoundingBoxConverter(Converter):
 
         if isinstance(cbbox, CompoundBoundingBox):
             return {
-                'selector_args': [
-                    {
-                        'argument': sa[0],
-                        'ignore': sa[1]
-                    } for sa in cbbox.selector_args
-                ],
-                'cbbox': [
-                    {
-                        'key': list(key),
-                        'bbox': bbox
-                    } for key, bbox in cbbox.bounding_boxes.items()
-                ],
-                'ignore': cbbox.global_ignored,
-                'order': cbbox.order
+                "selector_args": [{"argument": sa[0], "ignore": sa[1]} for sa in cbbox.selector_args],
+                "cbbox": [{"key": list(key), "bbox": bbox} for key, bbox in cbbox.bounding_boxes.items()],
+                "ignore": cbbox.global_ignored,
+                "order": cbbox.order,
             }
         else:
             raise TypeError(f"{cbbox} is not a valid CompoundBoundingBox!")
@@ -69,23 +55,18 @@ class CompoundBoundingBoxConverter(Converter):
     def from_yaml_tree(self, node, tag, ctx):
         from astropy.modeling.bounding_box import CompoundBoundingBox
 
-        selector_args = tuple([
-            (selector['argument'], selector['ignore']) for selector in node['selector_args']
-        ])
+        selector_args = tuple([(selector["argument"], selector["ignore"]) for selector in node["selector_args"]])
 
-        bounding_boxes = {
-            tuple(bbox['key']): bbox['bbox']
-            for bbox in node['cbbox']
-        }
+        bounding_boxes = {tuple(bbox["key"]): bbox["bbox"] for bbox in node["cbbox"]}
 
-        if 'ignore' in node:
-            ignored = node['ignore']
+        if "ignore" in node:
+            ignored = node["ignore"]
         else:
             ignored = None
 
-        if 'order' in node:
-            order = node['order']
+        if "order" in node:
+            order = node["order"]
         else:
-            order = 'C'
+            order = "C"
 
         return CompoundBoundingBox(bounding_boxes, selector_args=selector_args, ignored=ignored, order=order)

--- a/asdf_astropy/converters/transform/tests/test_transform.py
+++ b/asdf_astropy/converters/transform/tests/test_transform.py
@@ -43,7 +43,7 @@ def assert_model_roundtrip(model, tmpdir, version=None):
 
 def create_single_models():
     model_with_bounding_box = astropy_models.Shift(10)
-    model_with_bounding_box.bounding_box = ((1, 7),)
+    model_with_bounding_box.bounding_box = (1, 7)
 
     model_with_user_inverse = astropy_models.Shift(10)
     model_with_user_inverse.inverse = astropy_models.Shift(-7)

--- a/asdf_astropy/converters/transform/tests/test_transform.py
+++ b/asdf_astropy/converters/transform/tests/test_transform.py
@@ -9,7 +9,6 @@ from asdf.tests.helpers import yaml_to_asdf
 from astropy import units as u
 from astropy.modeling import models as astropy_models
 from astropy.modeling.bounding_box import CompoundBoundingBox, ModelBoundingBox
-from numpy.testing import assert_array_equal
 from packaging.version import Version
 
 from asdf_astropy import integration

--- a/asdf_astropy/converters/transform/tests/test_transform.py
+++ b/asdf_astropy/converters/transform/tests/test_transform.py
@@ -2,14 +2,14 @@ import itertools
 
 import asdf
 import astropy
-from astropy.modeling import models as astropy_models
-from astropy.modeling.bounding_box import ModelBoundingBox, CompoundBoundingBox
 import astropy.modeling
 import numpy as np
 import pytest
 from asdf.tests.helpers import yaml_to_asdf
 from astropy import units as u
 from astropy.modeling import models as astropy_models
+from astropy.modeling.bounding_box import CompoundBoundingBox, ModelBoundingBox
+from numpy.testing import assert_array_equal
 from packaging.version import Version
 
 from asdf_astropy import integration
@@ -293,9 +293,12 @@ def create_single_models():
 
     # model with compound bounding box
     model = astropy_models.Shift(1) & astropy_models.Scale(2) & astropy_models.Identity(1)
-    model.inputs = ('x', 'y', 'slit_id')
-    bounding_boxes = {(0,): ((-0.5, 1047.5), (-0.5, 2047.5)), (1,): ((-0.5, 3047.5), (-0.5, 4047.5)), }
-    bounding_box = CompoundBoundingBox.validate(model, bounding_boxes, selector_args=[('slit_id', True)], order='F')
+    model.inputs = ("x", "y", "slit_id")
+    bounding_boxes = {
+        (0,): ((-0.5, 1047.5), (-0.5, 2047.5)),
+        (1,): ((-0.5, 3047.5), (-0.5, 4047.5)),
+    }
+    bounding_box = CompoundBoundingBox.validate(model, bounding_boxes, selector_args=[("slit_id", True)], order="F")
     model.bounding_box = bounding_box
     result.append(model)
 
@@ -597,23 +600,26 @@ def create_bounding_boxes():
     model_bounding_box = [
         ModelBoundingBox((0, 1), astropy_models.Polynomial1D(1)),
         ModelBoundingBox(((0, 1), (2, 3)), astropy_models.Polynomial2D(1)),
-        ModelBoundingBox(((0, 1), (2, 3)), astropy_models.Polynomial2D(1), order='F'),
-        ModelBoundingBox((0, 1), astropy_models.Polynomial2D(1), ignored=['x']),
-        ModelBoundingBox((0, 1), astropy_models.Polynomial2D(1), ignored=['y']),
+        ModelBoundingBox(((0, 1), (2, 3)), astropy_models.Polynomial2D(1), order="F"),
+        ModelBoundingBox((0, 1), astropy_models.Polynomial2D(1), ignored=["x"]),
+        ModelBoundingBox((0, 1), astropy_models.Polynomial2D(1), ignored=["y"]),
     ]
     compound_bounding_box = [
-        CompoundBoundingBox({(1,): (0, 1), (2,): (2, 3)}, astropy_models.Polynomial2D(1), [('x', True)]),
-        CompoundBoundingBox({(1,): ((0, 1), (-1, 0)), (2,): ((2, 3), (-3, -2))},
-                            astropy_models.Polynomial2D(1), [('x', False)]),
-        CompoundBoundingBox({(1,): (0, 1), (2,): (2, 3)},
-                            astropy_models.Polynomial2D(1), [('x', False)], ignored=['x']),
-        CompoundBoundingBox({(1,): (0, 1), (2,): (2, 3)},
-                                             astropy_models.Polynomial2D(1), [('x', False)], ignored=['y']),
+        CompoundBoundingBox({(1,): (0, 1), (2,): (2, 3)}, astropy_models.Polynomial2D(1), [("x", True)]),
+        CompoundBoundingBox(
+            {(1,): ((0, 1), (-1, 0)), (2,): ((2, 3), (-3, -2))}, astropy_models.Polynomial2D(1), [("x", False)]
+        ),
+        CompoundBoundingBox(
+            {(1,): (0, 1), (2,): (2, 3)}, astropy_models.Polynomial2D(1), [("x", False)], ignored=["x"]
+        ),
+        CompoundBoundingBox(
+            {(1,): (0, 1), (2,): (2, 3)}, astropy_models.Polynomial2D(1), [("x", False)], ignored=["y"]
+        ),
     ]
 
     return model_bounding_box + compound_bounding_box
 
 
-@pytest.mark.parametrize('bbox', create_bounding_boxes())
+@pytest.mark.parametrize("bbox", create_bounding_boxes())
 def test_round_trip_bounding_box(bbox, tmpdir):
     assert_bounding_box_round_trip(bbox, tmpdir)

--- a/asdf_astropy/extensions.py
+++ b/asdf_astropy/extensions.py
@@ -20,6 +20,8 @@ from .converters.transform.projections import ProjectionConverter
 from .converters.transform.rotations import Rotate3DConverter, RotationSequenceConverter
 from .converters.transform.spline import SplineConverter
 from .converters.transform.tabular import TabularConverter
+from .converters.transform.properties import ModelBoundingBoxConverter, CompoundBoundingBoxConverter
+
 from .converters.unit.equivalency import EquivalencyConverter
 from .converters.unit.quantity import QuantityConverter
 from .converters.unit.unit import UnitConverter
@@ -360,6 +362,10 @@ TRANSFORM_CONVERTERS = [
     RotationSequenceConverter(),
     # astropy.modeling.tabular
     TabularConverter(),
+
+    # astropy.modeling.bounding_box
+    ModelBoundingBoxConverter(),
+    CompoundBoundingBoxConverter(),
 ]
 
 

--- a/asdf_astropy/extensions.py
+++ b/asdf_astropy/extensions.py
@@ -17,11 +17,10 @@ from .converters.transform.mappings import IdentityConverter, RemapAxesConverter
 from .converters.transform.math_functions import MathFunctionsConverter
 from .converters.transform.polynomial import OrthoPolynomialConverter, PolynomialConverter
 from .converters.transform.projections import ProjectionConverter
+from .converters.transform.properties import CompoundBoundingBoxConverter, ModelBoundingBoxConverter
 from .converters.transform.rotations import Rotate3DConverter, RotationSequenceConverter
 from .converters.transform.spline import SplineConverter
 from .converters.transform.tabular import TabularConverter
-from .converters.transform.properties import ModelBoundingBoxConverter, CompoundBoundingBoxConverter
-
 from .converters.unit.equivalency import EquivalencyConverter
 from .converters.unit.quantity import QuantityConverter
 from .converters.unit.unit import UnitConverter
@@ -362,7 +361,6 @@ TRANSFORM_CONVERTERS = [
     RotationSequenceConverter(),
     # astropy.modeling.tabular
     TabularConverter(),
-
     # astropy.modeling.bounding_box
     ModelBoundingBoxConverter(),
     CompoundBoundingBoxConverter(),

--- a/asdf_astropy/testing/helpers.py
+++ b/asdf_astropy/testing/helpers.py
@@ -95,6 +95,7 @@ def assert_model_equal(a, b):
 
     assert_array_equal(a.parameters, b.parameters)
 
+    assert a._user_bounding_box == b._user_bounding_box
     try:
         a_bounding_box = a.bounding_box
     except NotImplementedError:


### PR DESCRIPTION
This pull request adds converters to `asdf-astropy` in order to properly support the `bounding_box-1.0.0` and `compound_bounding_box-1.0.0` schemas in PR asdf-format/asdf-transform-schemas#31. This is related to PR: astropy/astropy#12769 because it ports those converters into this repository.

A major change in this PR is that default bounding boxes will no longer be serialized by asdf.

Note that the changes in PR astropy/astropy#12762 are needed to fully support this PR.