### PR TITLE
Bugfix for `units_mapping` asdf schema.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,9 @@
 
 - Add support for serialization and deserialization of input_units_equivalencies
   for astropy models. [#37]
+- Bugfix for units_mapping schema's property name conflicts. Changes:
+  - ``inputs`` to ``unit_inputs``
+  - ``outputs`` to ``unit_outputs``
 
 0.1.2 (2021-12-14)
 ------------------

--- a/asdf_astropy/converters/transform/mappings.py
+++ b/asdf_astropy/converters/transform/mappings.py
@@ -81,8 +81,8 @@ class UnitsMappingConverter(Converter):
                 output["unit"] = m[-1]
             outputs.append(output)
 
-        node["inputs"] = inputs
-        node["outputs"] = outputs
+        node["unit_inputs"] = inputs
+        node["unit_outputs"] = outputs
 
         return node
 
@@ -90,10 +90,10 @@ class UnitsMappingConverter(Converter):
         from astropy.modeling.mappings import UnitsMapping
 
         mapping = tuple((i.get("unit"), o.get("unit"))
-                        for i, o in zip(node["inputs"], node["outputs"]))
+                        for i, o in zip(node["unit_inputs"], node["unit_outputs"]))
 
         equivalencies = None
-        for i in node["inputs"]:
+        for i in node["unit_inputs"]:
             if "equivalencies" in i:
                 if equivalencies is None:
                     equivalencies = {}
@@ -102,7 +102,7 @@ class UnitsMappingConverter(Converter):
         kwargs = {
             "input_units_equivalencies": equivalencies,
             "input_units_allow_dimensionless": {
-                i["name"]: i.get("allow_dimensionless", False) for i in node["inputs"]},
+                i["name"]: i.get("allow_dimensionless", False) for i in node["unit_inputs"]},
         }
 
         if "name" in node:

--- a/asdf_astropy/resources/schemas/transform/units_mapping-1.0.0.yaml
+++ b/asdf_astropy/resources/schemas/transform/units_mapping-1.0.0.yaml
@@ -17,20 +17,20 @@ examples:
     - Assign units of seconds to dimensionless input.
     - |
       !<tag:astropy.org:astropy/transform/units_mapping-1.0.0>
-        inputs:
+        unit_inputs:
           - name: x
             unit: !unit/unit-1.0.0
-        outputs:
+        unit_outputs:
           - name: x
             unit: !unit/unit-1.0.0 s
   -
     - Convert input to meters, then assign dimensionless units.
     - |
       !<tag:astropy.org:astropy/transform/units_mapping-1.0.0>
-        inputs:
+        unit_inputs:
           - name: x
             unit: !unit/unit-1.0.0 m
-        outputs:
+        unit_outputs:
           - name: x
             unit: !unit/unit-1.0.0
 
@@ -38,19 +38,19 @@ examples:
     - Convert input to meters, then drop units entirely.
     - |
       !<tag:astropy.org:astropy/transform/units_mapping-1.0.0>
-        inputs:
+        unit_inputs:
           - name: x
             unit: !unit/unit-1.0.0 m
-        outputs:
+        unit_outputs:
           - name: x
 
   -
     - Accept any units, then replace with meters.
     - |
       !<tag:astropy.org:astropy/transform/units_mapping-1.0.0>
-        inputs:
+        unit_inputs:
           - name: x
-        outputs:
+        unit_outputs:
           - name: x
             unit: !unit/unit-1.0.0 m
 
@@ -58,19 +58,19 @@ allOf:
   - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.2.0"
   - type: object
     properties:
-      inputs:
+      unit_inputs:
         description: |
           Array of input configurations.
         type: array
         items:
           $ref: "#/definitions/value_configuration"
-      outputs:
+      unit_outputs:
         description: |
           Array of output configurations.
         type: array
         items:
           $ref: "#/definitions/value_configuration"
-    required: [inputs, outputs]
+    required: [unit_inputs, unit_outputs]
 
 definitions:
   value_configuration:


### PR DESCRIPTION
In asdf-format/asdf-transform-schemas#33, the `inputs` and `outputs` properties were formally added to the transform schema. This conflicts with the use of those fields in the `units_mapping` schema for other purposes. This PR fixes the bugs that result from this.

Note that this replicates the bugfix in PR astropy/astropy#12800.