### PR TITLE
Update `setuptools_scm`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ __pycache__
 
 # Other generated files
 MANIFEST
-asdf_astropy/version.py
+asdf_astropy/_version.py
 
 # Sphinx
 _build

--- a/asdf_astropy/_astropy_init.py
+++ b/asdf_astropy/_astropy_init.py
@@ -4,10 +4,7 @@ from astropy.tests.runner import TestRunner
 
 __all__ = ["__version__", "test"]
 
-try:
-    from .version import version as __version__
-except ImportError:
-    __version__ = ""
+from ._version import version as __version__
 
 # Create the test function for self test
 test = TestRunner.make_test_runner_in(os.path.dirname(__file__))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,13 @@
 [build-system]
-requires = ["setuptools",
-            "setuptools_scm",
+requires = ["setuptools>=42",
+            "setuptools_scm[toml]>=3.4",
             "wheel",
-            #"extension-helpers",
             "oldest-supported-numpy",
-            #"cython==0.29.14"
 	    ]
 build-backend = 'setuptools.build_meta'
+
+[tool.setuptools_scm]
+write_to = "asdf_astropy/_version.py"
 
 [tool.black]
 line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@
 # NOTE: The configuration for the package, including the name, version, and
 # other information are set in the setup.cfg file.
 
-import os
 import sys
 
 from setuptools import setup
@@ -62,16 +61,4 @@ if "build_docs" in sys.argv or "build_sphinx" in sys.argv:
     print(DOCS_HELP)
     sys.exit(1)
 
-VERSION_TEMPLATE = """
-# Note that we need to fall back to the hard-coded version if either
-# setuptools_scm can't be imported or setuptools_scm can't determine the
-# version, so we catch the generic 'Exception'.
-try:
-    from setuptools_scm import get_version
-    version = get_version(root='..', relative_to=__file__)
-except Exception:
-    version = '{version}'
-""".lstrip()
-
-
-setup(use_scm_version={"write_to": os.path.join("asdf_astropy", "version.py"), "write_to_template": VERSION_TEMPLATE})
+setup()


### PR DESCRIPTION
The use of `setuptools_scm` by this package has been deprecated in favor of a `pyproject.toml` based approach. This PR performs this update.