### PR TITLE
Remove python 3.7 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,6 @@ jobs:
             os: ubuntu-latest
             toxenv: py38-test
 
-          - name: Python 3.7 Tests
-            python-version: "3.7"
-            os: ubuntu-latest
-            toxenv: py37-test
-
           - name: Mac OS Latest
             python-version: "3.9"
             os: macos-latest

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,39,310}-test{,-alldeps}
+    py{39,310}-test{,-alldeps}
     py38-test-devdeps
     py38-cov
     py{38,}-test-numpy{117,118,119}


### PR DESCRIPTION
Astropy 5 only supports python 3.8+ which means using new astropy features will break the Python 3.7 CI. Hence, we are dropping it here.