### PR TITLE
Fix warnings from testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,11 @@ jobs:
             os: ubuntu-latest
             toxenv: codestyle
 
+          - name: Warnings Treated as Exceptions
+            os: ubuntu-latest
+            python-version: "3.9"
+            toxenv: warnings
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/tox.ini
+++ b/tox.ini
@@ -96,3 +96,12 @@ deps=
     toml
 commands=
     bandit -c bandit.yaml -r .
+
+[testenv:warnings]
+commands=
+    pip freeze
+    pytest --remote-data -W error \
+      -p no:unraisableexception \
+      -W ignore::asdf.exceptions.AsdfDeprecationWarning:asdf.asdftypes \
+      -W 'ignore:numpy.ndarray size changed:astropy.utils.exceptions.AstropyWarning' \
+      -W 'ignore:numpy.ndarray size changed:RuntimeWarning'


### PR DESCRIPTION
This fixes the warnings occurring during testing and adds a CI job which turns warnings into exceptions to catch these issues in the future.