### PR TITLE
Move documentation from astropy to asdf-astropy

### DIFF
--- a/docs/asdf-astropy/index.rst
+++ b/docs/asdf-astropy/index.rst
@@ -2,5 +2,16 @@
 asdf-astropy Documentation
 **************************
 
+The **asdf-astropy** package contains code that is used to serialize ``astropy``
+types so that they can be represented and stored using the Advanced Scientific
+Data Format (ASDF).
+
+If **asdf-astropy** is installed, no further configuration is required in order
+to process ASDF files that contain **astropy** types. This is becuase both **asdf**
+and **astropy** are required dependencies of **asdf-astropy**. Note that the **asdf**
+package has be designed to automatically detect the presence of tags defined by
+packages like **asdf-astropy** and automatically make use of that package's support
+infrastructure to operate correctly.
+
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Starts the process of moving documentation from astropy to asdf-astropy.

Fixes #53