### PR TITLE
Add converter for Schechter1D model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           - name: Python 3.9, Development Dependencies
             python-version: "3.9"
             os: ubuntu-latest
-            toxenv: py39-test-devdeps
+            toxenv: py39-test-devdeps-cov
 
           - name: Python 3.8 Tests
             python-version: "3.8"

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__
 # Other generated files
 MANIFEST
 asdf_astropy/_version.py
+coverage.xml
 
 # Sphinx
 _build

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+0.2.2 (unreleased)
+------------------
+
+- Add converter for the new ``Schechter1D`` model. [#67]
+
 0.2.1 (2022-04-18)
 ------------------
 

--- a/asdf_astropy/extensions.py
+++ b/asdf_astropy/extensions.py
@@ -1,4 +1,5 @@
 from asdf.extension import ManifestExtension
+from astropy.utils import minversion
 
 from .converters.coordinates.angle import AngleConverter, LatitudeConverter, LongitudeConverter
 from .converters.coordinates.earth_location import EarthLocationConverter
@@ -361,6 +362,14 @@ TRANSFORM_CONVERTERS = [
     # astropy.modeling.tabular
     TabularConverter(),
 ]
+
+if minversion("astropy", "5.1.0"):
+    TRANSFORM_CONVERTERS.append(
+        SimpleTransformConverter(
+            ["tag:stsci.edu:asdf/transform/schechter1d-*"],
+            "astropy.modeling.powerlaws.Schechter1D",
+        )
+    )
 
 
 # The order here is important; asdf will prefer to use extensions


### PR DESCRIPTION
The `Schechter1D` model was introduced to astropy in astropy/astropy#13116. Since, asdf-format/asdf-transform-schemas#54 was merged there is now a schema for `Schechter1D`. This PR adds the corresponding converter to handle this model.

Fixes #66.