### PR TITLE
Converters for `ModelBoundingBox` and `CompoundBoundingBox`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__
 MANIFEST
 asdf_astropy/_version.py
 coverage.xml
+.mypy_cache
 
 # Sphinx
 _build

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@
 - Update ``FrameConverter`` to enable the use of multiple tags. [#81]
 - Bugfixes for ``astropy.time`` converters. [#86]
 - Remove unnecessary ``tag:`` from schemas. [#103]
+- Add converters for ``ModelBoundingBox`` and ``CompoundBoundingBox``. [#69]
 
 0.2.1 (2022-04-18)
 ------------------

--- a/asdf_astropy/converters/transform/core.py
+++ b/asdf_astropy/converters/transform/core.py
@@ -134,7 +134,15 @@ class TransformConverterBase(Converter):
         bbox = model.bounding_box
 
         if minversion("asdf_transform_schemas", "0.2.2", inclusive=False):
-            bbox = ModelBoundingBox.validate(model, bbox)
+            if len(bbox.ignored) > 0:
+                if minversion("astropy", "5.1"):
+                    kwargs = {"_preserve_ignore": True}
+                else:
+                    raise RuntimeError("Bounding box ignored arguments are only supported by astropy 5.1+")
+            else:
+                kwargs = {}
+
+            bbox = ModelBoundingBox.validate(model, bbox, **kwargs)
         else:
             bbox = bbox.bounding_box(order="C")
 

--- a/asdf_astropy/converters/transform/core.py
+++ b/asdf_astropy/converters/transform/core.py
@@ -1,7 +1,5 @@
 import abc
-import warnings
 
-import numpy as np
 from asdf.extension import Converter
 
 from ..utils import import_type
@@ -125,56 +123,27 @@ class TransformConverterBase(Converter):
         return node
 
     def _serialize_bounding_box(self, model, node):
-        import astropy
-        from packaging.version import Version
+        # ignore any default bounding_box
+        if model._user_bounding_box is not None:
+            self._serialize_bounding_box_astropy(model, node)
 
-        if Version(astropy.__version__) > Version("4.999.999"):
-            self._serialize_bounding_box_astropy_5(model, node)
+    def _serialize_bounding_box_astropy(self, model, node):
+        from astropy.modeling.bounding_box import ModelBoundingBox
+        from astropy.utils import minversion
+
+        bbox = model.bounding_box
+
+        if minversion("asdf_transform_schemas", "0.2.2", inclusive=False):
+            bbox = ModelBoundingBox.validate(model, bbox)
         else:
-            self._serialize_bounding_box_astropy_4(model, node)
-
-    def _serialize_bounding_box_astropy_4(self, model, node):
-        try:
-            bb = model.bounding_box
-        except NotImplementedError:
-            bb = None
-
-        if bb is not None:
-            if model.n_inputs == 1:
-                bb = list(bb)
-            else:
-                bb = [list(item) for item in model.bounding_box]
-            node["bounding_box"] = bb
-
-    def _serialize_bounding_box_astropy_5(self, model, node):
-        from astropy.modeling.bounding_box import CompoundBoundingBox, ModelBoundingBox
-
-        try:
-            bb = model.bounding_box
-        except NotImplementedError:
-            bb = None
-
-        if isinstance(bb, ModelBoundingBox):
-            bb = bb.bounding_box(order="C")
+            bbox = bbox.bounding_box(order="C")
 
             if model.n_inputs == 1:
-                bb = list(bb)
+                bbox = list(bbox)
             else:
-                bb = [list(item) for item in bb]
-            node["bounding_box"] = bb
+                bbox = [list(item) for item in bbox]
 
-        elif isinstance(bb, CompoundBoundingBox):
-            selector_args = [[sa.index, sa.ignore] for sa in bb.selector_args]
-            node["selector_args"] = selector_args
-            node["cbbox_keys"] = list(bb.bounding_boxes.keys())
-
-            bounding_boxes = list(bb.bounding_boxes.values())
-            if len(model.inputs) - len(selector_args) == 1:
-                node["cbbox_values"] = [list(sbbox.bounding_box()) for sbbox in bounding_boxes]
-            else:
-                node["cbbox_values"] = [
-                    [list(item) for item in sbbox.bounding_box() if np.isfinite(item[0])] for sbbox in bounding_boxes
-                ]
+        node["bounding_box"] = bbox
 
     def from_yaml_tree(self, node, tag, ctx):
         from astropy.modeling.core import CompoundModel
@@ -209,31 +178,15 @@ class TransformConverterBase(Converter):
             model.inverse = node["inverse"]
 
     def _deserialize_bounding_box(self, model, node):
-        import astropy
-        from packaging.version import Version
-
-        if Version(astropy.__version__) > Version("4.999.999"):
-            self._deserialize_bounding_box_astropy_5(model, node)
-        else:
-            self._deserialize_bounding_box_astropy_4(model, node)
-
-    def _deserialize_bounding_box_astropy_4(self, model, node):
         if "bounding_box" in node:
-            model.bounding_box = node["bounding_box"]
-        elif "selector_args" in node:
-            warnings.warn("This version of astropy does not support compound bounding boxes.")
+            bounding_box = node["bounding_box"]
 
-    def _deserialize_bounding_box_astropy_5(self, model, node):
-        from astropy.modeling.bounding_box import CompoundBoundingBox
-
-        if "bounding_box" in node:
-            model.bounding_box = node["bounding_box"]
-        elif "selector_args" in node:
-            cbbox_keys = [tuple(key) for key in node["cbbox_keys"]]
-            bbox_dict = dict(zip(cbbox_keys, node["cbbox_values"]))
-
-            selector_args = node["selector_args"]
-            model.bounding_box = CompoundBoundingBox.validate(model, bbox_dict, selector_args)
+            if isinstance(bounding_box, list):
+                model.bounding_box = bounding_box
+            elif callable(bounding_box):
+                model.bounding_box = bounding_box(model)
+            else:
+                raise TypeError(f"Cannot form bounding_box from: {bounding_box}")
 
 
 class SimpleTransformConverter(TransformConverterBase):

--- a/asdf_astropy/converters/transform/properties.py
+++ b/asdf_astropy/converters/transform/properties.py
@@ -14,14 +14,63 @@ class ModelBoundingBoxConverter(Converter):
         }
 
     def from_yaml_tree(self, node, tag, ctx):
-        from astropy.modeling.bounding_box import ModelBoundingBox
+        from astropy.modeling.bounding_box import ModelBoundingBox, get_index, get_name
 
         intervals = {_input: tuple(interval) for _input, interval in node["intervals"].items()}
 
         if "ignore" in node:
             ignored = node["ignore"]
         else:
-            ignored = None
+            ignored = []
+
+        if "order" in node:
+            order = node["order"]
+        else:
+            order = "C"
+
+        def create_bounding_box(model, cbbox=None):
+            if len(ignored) > 0 and not minversion("astropy", "5.1"):
+                raise RuntimeError("Deserializing ignored elements of a bounding is only supported for astropy 5.1+")
+
+            # Hack to get compound_bounding_box to work for both 5.0.4 and 5.1
+            if cbbox is None:
+                ignore = ignored
+            else:
+                ignore = list(
+                    set(ignored + [get_name(model, get_index(model, key)) for key in cbbox.selector_args.ignore])
+                )
+
+            return ModelBoundingBox(intervals, model, ignored=ignore, order=order)
+
+        return create_bounding_box
+
+
+class CompoundBoundingBoxConverter(Converter):
+    tags = ["tag:stsci.edu:asdf/transform/property/compound_bounding_box-1.0.0"]
+    types = ["astropy.modeling.bounding_box.CompoundBoundingBox"]
+
+    def to_yaml_tree(self, cbbox, tag, ctx):
+        node = {
+            "selector_args": [{"argument": sa.name(cbbox._model), "ignore": sa.ignore} for sa in cbbox.selector_args],
+            "cbbox": [{"key": list(key), "bbox": bbox} for key, bbox in cbbox.bounding_boxes.items()],
+            "order": cbbox.order,
+        }
+
+        if minversion("astropy", "5.1"):
+            node["ignore"] = cbbox.ignored_inputs
+
+        return node
+
+    def from_yaml_tree(self, node, tag, ctx):
+        from astropy.modeling.bounding_box import CompoundBoundingBox
+
+        selector_args = tuple([(selector["argument"], selector["ignore"]) for selector in node["selector_args"]])
+        bboxes = {tuple(bbox["key"]): bbox["bbox"] for bbox in node["cbbox"]}
+
+        if "ignore" in node:
+            ignored = node["ignore"]
+        else:
+            ignored = []
 
         if "order" in node:
             order = node["order"]
@@ -29,9 +78,21 @@ class ModelBoundingBoxConverter(Converter):
             order = "C"
 
         def create_bounding_box(model):
-            if ignored is not None and not minversion("astropy", "5.1"):
-                raise RuntimeError("Deserializing ignored elements of a bounding is only supported for astropy 5.1+")
+            # bounding_boxes = {key: bbox(model) for key, bbox in bboxes.items()}
 
-            return ModelBoundingBox(intervals, model, ignored=ignored, order=order)
+            if not minversion("astropy", "5.1"):
+                if len(ignored) > 0:
+                    raise RuntimeError(
+                        "Deserializing ignored elements of a bounding is only supported for astropy 5.1+"
+                    )
+                else:
+                    cbbox = CompoundBoundingBox({}, model, selector_args, order=order)
+            else:
+                cbbox = CompoundBoundingBox({}, model, selector_args, ignored=ignored, order=order)
+
+            for key, bb in bboxes.items():
+                cbbox[key] = bb(model, cbbox)
+
+            return cbbox
 
         return create_bounding_box

--- a/asdf_astropy/converters/transform/properties.py
+++ b/asdf_astropy/converters/transform/properties.py
@@ -64,7 +64,7 @@ class CompoundBoundingBoxConverter(Converter):
     def from_yaml_tree(self, node, tag, ctx):
         from astropy.modeling.bounding_box import CompoundBoundingBox
 
-        selector_args = tuple([(selector["argument"], selector["ignore"]) for selector in node["selector_args"]])
+        selector_args = tuple((selector["argument"], selector["ignore"]) for selector in node["selector_args"])
         bboxes = {tuple(bbox["key"]): bbox["bbox"] for bbox in node["cbbox"]}
 
         if "ignore" in node:

--- a/asdf_astropy/converters/transform/properties.py
+++ b/asdf_astropy/converters/transform/properties.py
@@ -1,0 +1,33 @@
+from asdf.extension import Converter
+
+
+class ModelBoundingBoxConverter(Converter):
+    tags = ["tag:stsci.edu:asdf/transform/property/bounding_box-1.0.0"]
+    types = ["astropy.modeling.bounding_box.ModelBoundingBox"]
+
+    def to_yaml_tree(self, bbox, tag, ctx):
+        return {
+            "intervals": {_input: list(interval) for _input, interval in bbox.named_intervals.items()},
+            "ignore": list(bbox.ignored_inputs),
+            "order": bbox.order,
+        }
+
+    def from_yaml_tree(self, node, tag, ctx):
+        from astropy.modeling.bounding_box import ModelBoundingBox
+
+        intervals = {_input: tuple(interval) for _input, interval in node["intervals"].items()}
+
+        if "ignore" in node:
+            ignored = node["ignore"]
+        else:
+            ignored = None
+
+        if "order" in node:
+            order = node["order"]
+        else:
+            order = "C"
+
+        def create_bounding_box(model):
+            return ModelBoundingBox(intervals, model, ignored=ignored, order=order)
+
+        return create_bounding_box

--- a/asdf_astropy/converters/transform/properties.py
+++ b/asdf_astropy/converters/transform/properties.py
@@ -29,16 +29,16 @@ class ModelBoundingBoxConverter(Converter):
             order = "C"
 
         def create_bounding_box(model, cbbox=None):
-            if len(ignored) > 0 and not minversion("astropy", "5.1"):
-                raise RuntimeError("Deserializing ignored elements of a bounding is only supported for astropy 5.1+")
-
-            # Hack to get compound_bounding_box to work for both 5.0.4 and 5.1
             if cbbox is None:
                 ignore = ignored
             else:
+                # Hack to pass compound_bounding_box selector_args ignore in 5.0.4+
                 ignore = list(
                     set(ignored + [get_name(model, get_index(model, key)) for key in cbbox.selector_args.ignore])
                 )
+                # Add in globally ignored inputs from the compound_bounding_box in 5.1+
+                if minversion("astropy", "5.1"):
+                    ignore = list(set(ignore + [get_name(model, get_index(model, key)) for key in cbbox.ignored]))
 
             return ModelBoundingBox(intervals, model, ignored=ignore, order=order)
 

--- a/asdf_astropy/converters/transform/properties.py
+++ b/asdf_astropy/converters/transform/properties.py
@@ -1,4 +1,5 @@
 from asdf.extension import Converter
+from astropy.utils import minversion
 
 
 class ModelBoundingBoxConverter(Converter):
@@ -28,6 +29,9 @@ class ModelBoundingBoxConverter(Converter):
             order = "C"
 
         def create_bounding_box(model):
+            if ignored is not None and not minversion("astropy", "5.1"):
+                raise RuntimeError("Deserializing ignored elements of a bounding is only supported for astropy 5.1+")
+
             return ModelBoundingBox(intervals, model, ignored=ignored, order=order)
 
         return create_bounding_box

--- a/asdf_astropy/converters/transform/tests/test_transform.py
+++ b/asdf_astropy/converters/transform/tests/test_transform.py
@@ -313,6 +313,17 @@ def create_single_models():
         ),
     ]
 
+    # Test case for model with a metaclass generated abstract bounding_box
+    # where a custom bounding box is stored
+    gaussian_1d = astropy_models.Gaussian1D(10, 1.5, 0.25)
+    gaussian_1d.bounding_box = [7, 8]
+    result.append(gaussian_1d)
+
+    # compound model with bounding box
+    model = astropy_models.Shift(1) & astropy_models.Shift(2)
+    model.bounding_box = ((1, 2), (3, 4))
+    result.append(model)
+
     result.append(astropy_models.Plummer1D(mass=10.0, r_plum=5.0))
 
     # models with input_units_equivalencies

--- a/asdf_astropy/converters/transform/tests/test_transform.py
+++ b/asdf_astropy/converters/transform/tests/test_transform.py
@@ -324,6 +324,11 @@ def create_single_models():
     model.bounding_box = ((1, 2), (3, 4))
     result.append(model)
 
+    # compound model with bounding box
+    model = astropy_models.Shift(1) & astropy_models.Shift(2) & astropy_models.Shift(3)
+    model.bounding_box = ((1, 2), (3, 4), (5, 6))
+    result.append(model)
+
     result.append(astropy_models.Plummer1D(mass=10.0, r_plum=5.0))
 
     # models with input_units_equivalencies

--- a/asdf_astropy/converters/transform/tests/test_transform.py
+++ b/asdf_astropy/converters/transform/tests/test_transform.py
@@ -347,6 +347,28 @@ def create_single_models():
     model.bounding_box = ((1, 2), (3, 4), (5, 6))
     result.append(model)
 
+    if minversion("asdf_transform_schemas", "0.2.2", inclusive=False):
+        # model with compound bounding box
+        model = astropy_models.Shift(1) & astropy_models.Scale(2) & astropy_models.Identity(1)
+        model.inputs = ("x", "y", "slit_id")
+        bounding_boxes = {
+            (0,): ((-0.5, 1047.5), (-0.5, 2047.5)),
+            (1,): ((-0.5, 3047.5), (-0.5, 4047.5)),
+        }
+        bounding_box = CompoundBoundingBox.validate(model, bounding_boxes, selector_args=[("slit_id", True)], order="F")
+        model.bounding_box = bounding_box
+        result.append(model)
+
+        model = astropy_models.Shift(1) & astropy_models.Shift(2) & astropy_models.Shift(3)
+        model.inputs = ("x", "y", "z")
+        bounding_boxes = {
+            (0,): (1.0, 2.0),
+            (1,): (3.0, 4.0),
+        }
+        bounding_box = CompoundBoundingBox.validate(model, bounding_boxes, selector_args=[("x", True)], ignored=["y"])
+        model.bounding_box = bounding_box
+        result.append(model)
+
     result.append(astropy_models.Plummer1D(mass=10.0, r_plum=5.0))
 
     # models with input_units_equivalencies

--- a/asdf_astropy/converters/transform/tests/test_transform.py
+++ b/asdf_astropy/converters/transform/tests/test_transform.py
@@ -8,7 +8,7 @@ import pytest
 from asdf.tests.helpers import yaml_to_asdf
 from astropy import units as u
 from astropy.modeling import models as astropy_models
-from astropy.modeling.bounding_box import ModelBoundingBox
+from astropy.modeling.bounding_box import CompoundBoundingBox, ModelBoundingBox
 from astropy.utils import minversion
 
 from asdf_astropy import integration
@@ -46,7 +46,25 @@ def create_bounding_boxes():
             ]
         )
 
-    return model_bounding_box
+    compound_bounding_box = [
+        CompoundBoundingBox({(1,): (0, 1), (2,): (2, 3)}, astropy_models.Polynomial2D(1), [("x", True)]),
+        CompoundBoundingBox(
+            {(1,): ((0, 1), (-1, 0)), (2,): ((2, 3), (-3, -2))}, astropy_models.Polynomial2D(1), [("x", False)]
+        ),
+    ]
+    if minversion("astropy", "5.1"):
+        compound_bounding_box.extend(
+            [
+                CompoundBoundingBox(
+                    {(1,): (0, 1), (2,): (2, 3)}, astropy_models.Polynomial2D(1), [("x", False)], ignored=["x"]
+                ),
+                CompoundBoundingBox(
+                    {(1,): (0, 1), (2,): (2, 3)}, astropy_models.Polynomial2D(1), [("x", False)], ignored=["y"]
+                ),
+            ]
+        )
+
+    return model_bounding_box + compound_bounding_box
 
 
 @pytest.mark.parametrize("bbox", create_bounding_boxes())

--- a/asdf_astropy/converters/transform/tests/test_transform.py
+++ b/asdf_astropy/converters/transform/tests/test_transform.py
@@ -34,14 +34,26 @@ def create_bounding_boxes():
         ModelBoundingBox((0, 1), astropy_models.Polynomial1D(1)),
         ModelBoundingBox(((2, 3), (3, 4)), astropy_models.Polynomial2D(1)),
         ModelBoundingBox(((5, 6), (7, 8)), astropy_models.Polynomial2D(1), order="F"),
-        ModelBoundingBox((9, 10), astropy_models.Polynomial2D(1), ignored=["x"]),
-        ModelBoundingBox((11, 12), astropy_models.Polynomial2D(1), ignored=["y"]),
     ]
+
+    # ignore option is not properly supported until astropy versions with the bug fix from:
+    # astropy/astropy#13032 (milestone 5.0.5) is included
+    if minversion("astropy", "5.0.4", inclusive=False):
+        model_bounding_box.extend(
+            [
+                ModelBoundingBox((9, 10), astropy_models.Polynomial2D(1), ignored=["x"]),
+                ModelBoundingBox((11, 12), astropy_models.Polynomial2D(1), ignored=["y"]),
+            ]
+        )
 
     return model_bounding_box
 
 
 @pytest.mark.parametrize("bbox", create_bounding_boxes())
+@pytest.mark.skipif(
+    not minversion("asdf_transform_schemas", "0.2.2", inclusive=False),
+    reason="Schema not present until versions after asdf-transform-schemas 0.2.2",
+)
 def test_round_trip_bounding_box(bbox, tmpdir):
     assert_bounding_box_roundtrip(bbox, tmpdir)
 
@@ -368,6 +380,11 @@ UNSUPPORTED_MODELS = [
 ]
 
 if minversion("astropy", "5.1") and not minversion("asdf-transform-schemas", "0.2.3"):
+    UNSUPPORTED_MODELS.append(astropy.modeling.powerlaws.Schechter1D)
+
+
+# Model added in astropy 5.1 and schema added after asdf-transform 0.2.2
+if minversion("astropy", "5.1") and not minversion("asdf_transform_schemas", "0.2.2", inclusive=False):
     UNSUPPORTED_MODELS.append(astropy.modeling.powerlaws.Schechter1D)
 
 

--- a/asdf_astropy/extensions.py
+++ b/asdf_astropy/extensions.py
@@ -18,7 +18,7 @@ from .converters.transform.mappings import IdentityConverter, RemapAxesConverter
 from .converters.transform.math_functions import MathFunctionsConverter
 from .converters.transform.polynomial import OrthoPolynomialConverter, PolynomialConverter
 from .converters.transform.projections import ProjectionConverter
-from .converters.transform.properties import ModelBoundingBoxConverter
+from .converters.transform.properties import CompoundBoundingBoxConverter, ModelBoundingBoxConverter
 from .converters.transform.rotations import Rotate3DConverter, RotationSequenceConverter
 from .converters.transform.spline import SplineConverter
 from .converters.transform.tabular import TabularConverter
@@ -364,6 +364,7 @@ TRANSFORM_CONVERTERS = [
     TabularConverter(),
     # astropy.modeling.bounding_box
     ModelBoundingBoxConverter(),
+    CompoundBoundingBoxConverter(),
 ]
 
 if minversion("astropy", "5.1.0"):

--- a/asdf_astropy/extensions.py
+++ b/asdf_astropy/extensions.py
@@ -18,6 +18,7 @@ from .converters.transform.mappings import IdentityConverter, RemapAxesConverter
 from .converters.transform.math_functions import MathFunctionsConverter
 from .converters.transform.polynomial import OrthoPolynomialConverter, PolynomialConverter
 from .converters.transform.projections import ProjectionConverter
+from .converters.transform.properties import ModelBoundingBoxConverter
 from .converters.transform.rotations import Rotate3DConverter, RotationSequenceConverter
 from .converters.transform.spline import SplineConverter
 from .converters.transform.tabular import TabularConverter
@@ -361,6 +362,8 @@ TRANSFORM_CONVERTERS = [
     RotationSequenceConverter(),
     # astropy.modeling.tabular
     TabularConverter(),
+    # astropy.modeling.bounding_box
+    ModelBoundingBoxConverter(),
 ]
 
 if minversion("astropy", "5.1.0"):

--- a/asdf_astropy/testing/helpers.py
+++ b/asdf_astropy/testing/helpers.py
@@ -105,6 +105,7 @@ def assert_model_equal(a, b):
 
     assert_array_equal(a.parameters, b.parameters)
 
+    assert a._user_bounding_box == b._user_bounding_box
     try:
         a_bounding_box = a.bounding_box
     except NotImplementedError:


### PR DESCRIPTION
This PR adds converters for the bounding_box and compound_bounding_box properties in asdf-transform-schemas.

Closes #38, Closes #60, and closes astropy/astropy#12696