### PR TITLE
Updates from astropy coordinated package review

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@
 
 - Add converter for the new ``Schechter1D`` model. [#67]
 - Add CITATION file. [#71]
-- Add migration and quick-start documentation guides, and update minimum python version [#77]
+- Add migration and quick-start documentation guides, and update minimum Python version [#77]
 
 0.2.1 (2022-04-18)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@
 
 - Add converter for the new ``Schechter1D`` model. [#67]
 - Add CITATION file. [#71]
+- Add migration and quick-start documentation guides, and update minimum python version [#77]
 
 0.2.1 (2022-04-18)
 ------------------

--- a/docs/asdf-astropy/details.rst
+++ b/docs/asdf-astropy/details.rst
@@ -23,7 +23,7 @@ Similarly, the converters in **asdf-astropy** related to coordinates implement
 the tags that are defined by the
 `asdf-coordinates-schemas package <https://github.com/asdf-format/asdf-coordinates-schemas>`_.
 Moreover, many of the converters in **asdf-astropy** related to units implement tags
-that are defined in the `ASDF-standard <https://asdf-standard.readthedocs.io/en/latest/>`.
+that are defined in the :ref:`ASDF-standard <asdf-standard:asdf-standard>`.
 Finally, there are converters in **asdf-astropy** whose tags are defined within **asdf-astropy**
 itself. See :ref:`asdf-astropy_manifest` for a listing of all these tags. Documentation of the
 individual schemas defined by **asdf-astropy**, which are used to assemble these tags can be
@@ -34,5 +34,5 @@ found in :ref:`asdf-astropy_schemas`.
     write unsupported types to an ASDF file will lead to a ``RepresenterError``. In
     order to support new types, new tags and converters must be created. A basic
     example can be found in :ref:`basic_example`, for additional details please refer to
-    `Writing ASDF Extensions <https://asdf.readthedocs.io/en/latest/asdf/extending/extensions.html>`_.
+    :ref:`asdf:extending_extensions`.
     If you do write additional converters or schemas please consider contributing them to **asdf-astropy**.

--- a/docs/asdf-astropy/example.rst
+++ b/docs/asdf-astropy/example.rst
@@ -85,12 +85,12 @@ use of it when creating the tag in **ASDF**.
 
 .. note::
 
-   This is not a complete manifest, instead it is a listing for a single
-   tag for a manifest. See :ref:`asdf-astropy_manifest` for an example of
-   a complete manifest. Moreover, a manifest is not strictly the only way
-   to create a tag for ASDF (this can be done using the ASDF context manager
-   for example); however, it is the standard way to create a tag for ASDF
-   for use with a given package.
+    This is not a complete manifest, instead it is a listing for a single
+    tag for a manifest. See :ref:`asdf-astropy_manifest` for an example of
+    a complete manifest. Moreover, a manifest is not strictly the only way
+    to create a tag for ASDF (this can be done using the ASDF context manager
+    for example); however, it is the standard way to create a tag for ASDF
+    for use with a given package.
 
 Creating a Converter
 --------------------
@@ -114,7 +114,7 @@ If we want to use the **asdf-astropy** framework for writing transform converter
 will perform the serialization of the parts of ``MyModel`` which are specific to ``MyModel``,
 while ``from_yaml_tree_transform`` will perform the deserialization of the parts of
 ``MyModel`` specific to ``MyModel``. Moreover, the converter class must also
-specify the `tags` corresponding to ``MyModel`` and the matching python `types` for
+specify the `tags` corresponding to ``MyModel`` and the matching Python `types` for
 those `tags`. The `tags` are what **ASDF** uses to identify which converter to use when
 deserializing an ASDF file, while the `types` are used by **ASDF** to identify which converter
 to use when serializing an object to an ASDF file.::
@@ -153,14 +153,14 @@ In this case `tags` and `types` must still be defined, but instead
 
     class MyTypeConverter(Converter):
         tags = ["tag:<tag for MyType"]
-        types = ["<python import for MyType>"]
+        types = ["<Python import for MyType>"]
 
         def to_yaml_tree(self, obj, tag, ctx):
-            """Code to create a python dictionary representing MyType"""
+            """Code to create a Python dictionary representing MyType"""
             ...
 
         def from_yaml_tree(self, node, tag, ctx):
-            """Code to read a python dictionary representing MyType"""
+            """Code to read a Python dictionary representing MyType"""
             ...
 
 For more details please see :ref:`asdf:extending_extensions`.

--- a/docs/asdf-astropy/example.rst
+++ b/docs/asdf-astropy/example.rst
@@ -163,4 +163,4 @@ In this case `tags` and `types` must still be defined, but instead
             """Code to read a python dictionary representing MyType"""
             ...
 
-For more details please see `Writing ASDF Extensions <https://asdf.readthedocs.io/en/latest/asdf/extending/extensions.html>`_.
+For more details please see :ref:`asdf:extending_extensions`.

--- a/docs/asdf-astropy/manifest.rst
+++ b/docs/asdf-astropy/manifest.rst
@@ -7,4 +7,4 @@
 Documentation of the ASDF manifest for **asdf-astropy** can be found below:
 
 .. literalinclude:: ../../asdf_astropy/resources/manifests/astropy-1.0.0.yaml
-   :language: yaml
+    :language: yaml

--- a/docs/asdf-astropy/manifest.rst
+++ b/docs/asdf-astropy/manifest.rst
@@ -1,8 +1,8 @@
 .. _asdf-astropy_manifest:
 
-=====================
-asdf-astropy Manifest
-=====================
+=========================
+**asdf-astropy** Manifest
+=========================
 
 Documentation of the ASDF manifest for **asdf-astropy** can be found below:
 

--- a/docs/asdf-astropy/migrating.rst
+++ b/docs/asdf-astropy/migrating.rst
@@ -14,9 +14,9 @@ the interface used by **asdf-astropy** to extend **ASDF** is given preference ov
 
 .. note::
 
-	When **ASDF** version 3.0 is released, the interface used by **astropy.io.misc.asdf** will
-	be removed. This means that using **ASDF** with **astropy** will stop functioning unless
-	**asdf-astropy** is installed.
+    When **ASDF** version 3.0 is released, the interface used by **astropy.io.misc.asdf** will
+    be removed. This means that using **ASDF** with **astropy** will stop functioning unless
+    **asdf-astropy** is installed.
 
 The only users of **astropy.io.misc.asdf** that need to do any code migration aside from adding
 an **asdf-astropy** dependency are those who directly use the objects (based on `~asdf.types.CustomType`)

--- a/docs/asdf-astropy/migrating.rst
+++ b/docs/asdf-astropy/migrating.rst
@@ -1,0 +1,24 @@
+.. _migrating:
+
+Migrating from `~astropy.io.misc.asdf` to `asdf-astropy`
+========================================================
+
+For the majority of users, migrating from `~astropy.io.misc.asdf` to `asdf-astropy`
+requires no code changes at all. Instead, all users need to do is include `asdf-astropy`
+as an additional dependency to their package.
+
+This is because when the `asdf-astropy` package is installed, it will automatically be used
+by `asdf` when serializing and deserializing `astropy` objects. This is occurs seamlessly because
+the interface used by `asdf-astropy` to extend `asdf` is given preference over the one used by
+`~astropy.io.misc.asdf` (which is currently depreciated).
+
+.. note::
+
+    When `asdf` version 3.0 is released, the interface used by `~astropy.io.misc.asdf` will
+    be removed. This means that using `asdf` with `astropy` will stop functioning unless
+    `asdf-astropy` is installed.
+
+The only users of `~astropy.io.misc.asdf` that need to do any code migration aside from adding
+an `asdf-astropy` dependency are those who directly use the objects (based on `CustomType`) defined
+in `~astropy.io.misc.asdf` to create their own `asdf` converter extensions. Clear instructions on
+how to create the new extensions for `asdf` can be found in :ref:`asdf:extending_converters`.

--- a/docs/asdf-astropy/migrating.rst
+++ b/docs/asdf-astropy/migrating.rst
@@ -8,9 +8,9 @@ requires no code changes at all. Instead, all users need to do is include `asdf-
 as an additional dependency to their package.
 
 This is because when the `asdf-astropy` package is installed, it will automatically be used
-by `asdf` when serializing and deserializing `astropy` objects. This is occurs seamlessly because
+by `asdf` when serializing and deserializing `astropy` objects. This occurs seamlessly because
 the interface used by `asdf-astropy` to extend `asdf` is given preference over the one used by
-`~astropy.io.misc.asdf` (which is currently depreciated).
+`~astropy.io.misc.asdf` (which is currently deprecated).
 
 .. note::
 

--- a/docs/asdf-astropy/migrating.rst
+++ b/docs/asdf-astropy/migrating.rst
@@ -1,24 +1,25 @@
 .. _migrating:
 
-Migrating from `~astropy.io.misc.asdf` to `asdf-astropy`
-========================================================
+Migrating from **astropy.io.misc.asdf** to **asdf-astropy**
+===========================================================
 
-For the majority of users, migrating from `~astropy.io.misc.asdf` to `asdf-astropy`
-requires no code changes at all. Instead, all users need to do is include `asdf-astropy`
+For the majority of users, migrating from **astropy.io.misc.asdf** to **asdf-astropy**
+requires no code changes at all. Instead, all users need to do is include **asdf-astropy**
 as an additional dependency to their package.
 
-This is because when the `asdf-astropy` package is installed, it will automatically be used
-by `asdf` when serializing and deserializing `astropy` objects. This occurs seamlessly because
-the interface used by `asdf-astropy` to extend `asdf` is given preference over the one used by
-`~astropy.io.misc.asdf` (which is currently deprecated).
+This is because when the **asdf-astropy** package is installed, it will automatically be used
+by **ASDF** when serializing and deserializing **astropy** objects. This occurs seamlessly because
+the interface used by **asdf-astropy** to extend **ASDF** is given preference over the one used by
+**astropy.io.misc.asdf** (which is currently deprecated).
 
 .. note::
 
-    When `asdf` version 3.0 is released, the interface used by `~astropy.io.misc.asdf` will
-    be removed. This means that using `asdf` with `astropy` will stop functioning unless
-    `asdf-astropy` is installed.
+	When **ASDF** version 3.0 is released, the interface used by **astropy.io.misc.asdf** will
+	be removed. This means that using **ASDF** with **astropy** will stop functioning unless
+	**asdf-astropy** is installed.
 
-The only users of `~astropy.io.misc.asdf` that need to do any code migration aside from adding
-an `asdf-astropy` dependency are those who directly use the objects (based on `CustomType`) defined
-in `~astropy.io.misc.asdf` to create their own `asdf` converter extensions. Clear instructions on
-how to create the new extensions for `asdf` can be found in :ref:`asdf:extending_converters`.
+The only users of **astropy.io.misc.asdf** that need to do any code migration aside from adding
+an **asdf-astropy** dependency are those who directly use the objects (based on `~asdf.types.CustomType`)
+defined in **astropy.io.misc.asdf** to create their own **ASDF** `~asdf.extension._converter.Converter`
+extensions. Clear instructions on how to create the new converter extensions for **ASDF** can be found
+in :ref:`asdf:extending_converters`.

--- a/docs/asdf-astropy/quickstart.rst
+++ b/docs/asdf-astropy/quickstart.rst
@@ -4,19 +4,20 @@
 Quick-Start
 ***********
 
-`asdf-astropy` is intended to be an extension library for `asdf` to enable support
-for the `astropy` package.  It is intended to be used in conjunction with both the
-`asdf` and `astropy` packages. To this end, the `asdf-astropy` package typically
+**asdf-astropy** is intended to be an extension library for **ASDF** to enable support
+for the **astropy** package.  It is intended to be used in conjunction with both the
+**ASDF** and **astropy** packages. To this end, the **asdf-astropy** package typically
 only needs to be installed in order to provide its functionality.
 
-A quick example of `asdf`
-=========================
+A quick example of **ASDF**
+===========================
 
-The `asdf` format is a way of saving nested structures to `yaml`, where some of
+The **ASDF** format is a way of saving nested structures to **yaml**, where some of
 the stored data can be stored in a binary format. Thus, one typically structures
-an `asdf` file as a dictionary, with key/value pairs.
+an **ASDF** file as a dictionary, with key/value pairs.
 
-For example if one wanted to store an `astropy`` Gaussian model in an `asdf` file::
+For example if one wanted to store a :class:`Gaussian1D <astropy.modeling.functional_models.Gaussian1D>` model in
+an **ASDF** file::
 
     from asdf import AsdfFile
     from astropy.modeling.models import Gaussian1D
@@ -45,14 +46,13 @@ or as a context manager::
     with asdf.open("hello_world.asdf") as ff:
         ...
 
-In either case the file `ff` will be an `AsdfFile` object which is accessible just
-like a python dictionary. `asdf` will fully realize all of the objects stored within
-the file automatically. For example, to access the model stored in the file
-``ff['gaussian_model']`` will be a `Gaussian1D` object exactly matching the model
-written originally.
+In either case the file ``ff`` will be an `asdf.AsdfFile` object which is accessible just
+like a python dictionary. **ASDF** will fully realize all of the objects stored within
+the file automatically. For example, to access the model stored in the file ``ff['gaussian_model']``
+will be a `~astropy.modeling.models.Gaussian1D` object exactly matching the model written originally.
 
-One can also update an existing file. For example, if one wanted to update the
-``hello_world.asdf`` file with a `SkyCoord` object::
+One can also update an existing file. For example, if one wanted to update the ``hello_world.asdf``
+file with a `~astropy.coordinates.SkyCoord` object::
 
     import asdf
     from astropy import units as u
@@ -65,11 +65,12 @@ One can also update an existing file. For example, if one wanted to update the
         af.tree['skycoord'] = coord
         af.update()
 
-In the same way that the `Gaussian1D` model round-tripped, the `SkyCoord` object
-will also round-trip.
+In the same way that the `~astropy.modeling.models.Gaussian1D` model round-tripped, the
+`~astropy.coordinates.SkyCoord` object will also round-trip.
 
 Further Reading
 ===============
 
-If one wants to find more examples of how to write `astropy` Tables to `asdf` files,
-see :ref:`table`. For further reading on `asdf`.
+For further getting started material on **ASDF** see, :ref:`asdf:overview`. If one
+wants to find more examples of how to write an **astropy** `~astropy.table.Table`
+to **ASDF** files, see :ref:`table`.

--- a/docs/asdf-astropy/quickstart.rst
+++ b/docs/asdf-astropy/quickstart.rst
@@ -1,0 +1,75 @@
+.. _quickstart:
+
+***********
+Quick-Start
+***********
+
+`asdf-astropy` is intended to be an extension library for `asdf` to enable support
+for the `astropy` package.  It is intended to be used in conjunction with both the
+`asdf` and `astropy` packages. To this end, the `asdf-astropy` package typically
+only needs to be installed in order to provide its functionality.
+
+A quick example of `asdf`
+=========================
+
+The `asdf` format is a way of saving nested structures to `yaml`, where some of
+the stored data can be stored in a binary format. Thus, one typically structures
+an `asdf` file as a dictionary, with key/value pairs.
+
+For example if one wanted to store an `astropy`` Gaussian model in an `asdf` file::
+
+    from asdf import AsdfFile
+    from astropy.modeling.models import Gaussian1D
+
+    # Create a Gaussian1D model
+    model = Gaussian1D(amplitude=10.4, mean=3.2, stddev=0.1)
+
+    # Create a tree structure for the ASDF file, and write it.
+    tree = {'gaussian_model': model}
+    ff = AsdfFile(tree)
+    ff.write_to("hello_world.asdf")
+
+    # One can also create the file first, and then modify it directly.
+    ff = AsdfFile()
+    ff.tree['gaussian_model'] = model
+    ff.write_to("hello_world.asdf")
+
+To open the existing file one can use the top-level `asdf.open` method directly
+or as a context manager::
+
+    import asdf
+
+    ff = asdf.open("hello_world.asdf")
+
+    # As a context manager
+    with asdf.open("hello_world.asdf") as ff:
+        ...
+
+In either case the file `ff` will be an `AsdfFile` object which is accessible just
+like a python dictionary. `asdf` will fully realize all of the objects stored within
+the file automatically. For example, to access the model stored in the file
+``ff['gaussian_model']`` will be a `Gaussian1D` object exactly matching the model
+written originally.
+
+One can also update an existing file. For example, if one wanted to update the
+``hello_world.asdf`` file with a `SkyCoord` object::
+
+    import asdf
+    from astropy import units as u
+    from astropy.coordinates import SkyCoord
+
+    # Create a SkyCoord object
+    coord = SkyCoord(ra=10.625*u.degree, dec=41.2*u.degree, frame='icrs')
+
+    with asdf.open("hello_world.asdf", mode='rw') as af:
+        af.tree['skycoord'] = coord
+        af.update()
+
+In the same way that the `Gaussian1D` model round-tripped, the `SkyCoord` object
+will also round-trip.
+
+Further Reading
+===============
+
+If one wants to find more examples of how to write `astropy` Tables to `asdf` files,
+see :ref:`table`. For further reading on `asdf`.

--- a/docs/asdf-astropy/quickstart.rst
+++ b/docs/asdf-astropy/quickstart.rst
@@ -16,7 +16,7 @@ The **ASDF** format is a way of saving nested structures to **yaml**, where some
 the stored data can be stored in a binary format. Thus, one typically structures
 an **ASDF** file as a dictionary, with key/value pairs.
 
-For example if one wanted to store a :class:`Gaussian1D <astropy.modeling.functional_models.Gaussian1D>` model in
+For example if one wanted to store a `~astropy.modeling.functional_models.Gaussian1D` model in
 an **ASDF** file::
 
     from asdf import AsdfFile
@@ -47,9 +47,10 @@ or as a context manager::
         ...
 
 In either case the file ``ff`` will be an `asdf.AsdfFile` object which is accessible just
-like a python dictionary. **ASDF** will fully realize all of the objects stored within
+like a Python dictionary. **ASDF** will fully realize all of the objects stored within
 the file automatically. For example, to access the model stored in the file ``ff['gaussian_model']``
-will be a `~astropy.modeling.models.Gaussian1D` object exactly matching the model written originally.
+will be a `~astropy.modeling.functional_models.Gaussian1D` object exactly matching the model written
+originally.
 
 One can also update an existing file. For example, if one wanted to update the ``hello_world.asdf``
 file with a `~astropy.coordinates.SkyCoord` object::
@@ -65,7 +66,7 @@ file with a `~astropy.coordinates.SkyCoord` object::
         af.tree['skycoord'] = coord
         af.update()
 
-In the same way that the `~astropy.modeling.models.Gaussian1D` model round-tripped, the
+In the same way that the `~astropy.modeling.functional_models.Gaussian1D` model round-tripped, the
 `~astropy.coordinates.SkyCoord` object will also round-trip.
 
 Further Reading

--- a/docs/asdf-astropy/schemas.rst
+++ b/docs/asdf-astropy/schemas.rst
@@ -27,7 +27,7 @@ fits/fits-1.0.0
 ^^^^^^^^^^^^^^^
 
 .. literalinclude:: ../../asdf_astropy/resources/schemas/fits/fits-1.0.0.yaml
-   :language: yaml
+    :language: yaml
 
 
 Table
@@ -40,7 +40,7 @@ table/table-1.0.0
 ^^^^^^^^^^^^^^^^^
 
 .. literalinclude:: ../../asdf_astropy/resources/schemas/table/table-1.0.0.yaml
-   :language: yaml
+    :language: yaml
 
 
 Time
@@ -53,7 +53,7 @@ time/timedelta-1.0.0
 ^^^^^^^^^^^^^^^^^^^^
 
 .. literalinclude:: ../../asdf_astropy/resources/schemas/time/timedelta-1.0.0.yaml
-   :language: yaml
+    :language: yaml
 
 
 Units
@@ -66,4 +66,4 @@ units/equivalency-1.0.0
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 .. literalinclude:: ../../asdf_astropy/resources/schemas/units/equivalency-1.0.0.yaml
-   :language: yaml
+    :language: yaml

--- a/docs/asdf-astropy/schemas.rst
+++ b/docs/asdf-astropy/schemas.rst
@@ -1,9 +1,9 @@
 .. _asdf-astropy_schemas:
 
 
-====================
-asdf-astropy Schemas
-====================
+========================
+**asdf-astropy** Schemas
+========================
 
 Documentation for each of the individual ASDF schemas defined by **asdf-astropy** can
 be found at the links below.
@@ -20,7 +20,7 @@ and
 FITS
 ----
 
-The following schemas are associated with ``astropy`` types from the
+The following schemas are associated with **astropy** objects from the
 :ref:`astropy-io-fits` submodule:
 
 fits/fits-1.0.0
@@ -33,7 +33,7 @@ fits/fits-1.0.0
 Table
 -----
 
-The following schemas are associated with ``astropy`` types from the
+The following schemas are associated with **astropy** objects from the
 :ref:`astropy-table` submodule:
 
 table/table-1.0.0
@@ -46,7 +46,7 @@ table/table-1.0.0
 Time
 ----
 
-The following schemas are associated with ``astropy`` types from the
+The following schemas are associated with **astropy** objects from the
 :ref:`astropy-time` submodule:
 
 time/timedelta-1.0.0
@@ -59,7 +59,7 @@ time/timedelta-1.0.0
 Units
 -----
 
-The following schemas are associated with ``astropy`` types from the
+The following schemas are associated with **astropy** objects from the
 :ref:`astropy-units` submodule:
 
 units/equivalency-1.0.0

--- a/docs/asdf-astropy/schemas.rst
+++ b/docs/asdf-astropy/schemas.rst
@@ -8,8 +8,7 @@ asdf-astropy Schemas
 Documentation for each of the individual ASDF schemas defined by **asdf-astropy** can
 be found at the links below.
 
-Documentation for the schemas defined in the ASDF Standard can be found `here
-<https://asdf-standard.readthedocs.io/en/latest/schemas/index.html>`__.
+Documentation for the schemas defined in the ASDF Standard can be found :ref:`here <asdf-standard:schema>`.
 Note that other schemas are defined in
 `asdf-transform-schemas <https://github.com/asdf-format/asdf-transform-schemas>`_
 and

--- a/docs/asdf-astropy/table.rst
+++ b/docs/asdf-astropy/table.rst
@@ -17,7 +17,7 @@ Given a table, it is possible to write it out to an **ASDF** file::
 
     # Create a simple table
     t = Table(dtype=[('a', 'f4'), ('b', 'i4'), ('c', 'S2')])
-    # Write the table to an **ASDF** file
+    # Write the table to an ASDF file
     t.write('table.asdf')
 
 The I/O registry automatically selects the appropriate writer function to use

--- a/docs/asdf-astropy/table.rst
+++ b/docs/asdf-astropy/table.rst
@@ -40,9 +40,8 @@ Advanced Usage
 ^^^^^^^^^^^^^^
 
 The fundamental ASDF data structure is the tree, which is a nested
-combination of basic data structures (see `this
-<https://asdf.readthedocs.io/en/latest/asdf/features.html#data-model>`_
-for a more detailed description). At the top level, the tree is a `dict`.
+combination of basic data structures (see :ref:`asdf:data-model` for a more
+detailed description). At the top level, the tree is a `dict`.
 
 The consequence of this is that a `~astropy.table.Table` object (or any object,
 for that matter) can be stored at any arbitrary location within an ASDF tree.

--- a/docs/asdf-astropy/table.rst
+++ b/docs/asdf-astropy/table.rst
@@ -13,12 +13,12 @@ Basic Usage
 
 Given a table, it is possible to write it out to an **ASDF** file::
 
-	from astropy.table import Table
+    from astropy.table import Table
 
-	# Create a simple table
-	t = Table(dtype=[('a', 'f4'), ('b', 'i4'), ('c', 'S2')])
-	# Write the table to an **ASDF** file
-	t.write('table.asdf')
+    # Create a simple table
+    t = Table(dtype=[('a', 'f4'), ('b', 'i4'), ('c', 'S2')])
+    # Write the table to an **ASDF** file
+    t.write('table.asdf')
 
 The I/O registry automatically selects the appropriate writer function to use
 based on the ``.asdf`` extension of the output file.
@@ -26,7 +26,7 @@ based on the ``.asdf`` extension of the output file.
 Reading a file generated in this way is also possible using
 `~astropy.table.Table.read`::
 
-	t2 = Table.read('table.asdf')
+    t2 = Table.read('table.asdf')
 
 The I/O registry automatically selects the appropriate reader function based on
 the extension of the input file.
@@ -34,7 +34,7 @@ the extension of the input file.
 In the case of both reading and writing, if the file extension is not ``.asdf``
 it is possible to explicitly specify the reader/writer function to be used::
 
-	t3 = Table.read('table.zxcv', format='asdf')
+    t3 = Table.read('table.zxcv', format='asdf')
 
 Advanced Usage
 ^^^^^^^^^^^^^^
@@ -54,16 +54,16 @@ key to be used for storage and retrieval of a `~astropy.table.Table` from an
 **ASDF** file. For this reason, the **ASDF** I/O interface provides ``data_key`` as an
 optional keyword when writing and reading::
 
-	from astropy.table import Table
+    from astropy.table import Table
 
-	t = Table(dtype=[('a', 'f4'), ('b', 'i4'), ('c', 'S2')])
-	# Write the table to an asdf file using a non-default key
-	t.write('foo.asdf', data_key='foo')
+    t = Table(dtype=[('a', 'f4'), ('b', 'i4'), ('c', 'S2')])
+    # Write the table to an asdf file using a non-default key
+    t.write('foo.asdf', data_key='foo')
 
 A `~astropy.table.Table` stored using a custom data key can be retrieved by
 passing the same argument to `~astropy.table.Table.read`::
 
-	foo = Table.read('foo.asdf', data_key='foo')
+    foo = Table.read('foo.asdf', data_key='foo')
 
 The ``data_key`` option only applies to `~astropy.table.Table` objects that are
 stored at the top of the **ASDF** tree. For full generality, users may pass a
@@ -73,13 +73,13 @@ write case is ``make_tree``. The function callback should accept exactly one
 argument, which is the `~astropy.table.Table` object, and should return a
 `dict` representing the tree to be stored::
 
-	def make_custom_tree(table):
-		# Return a nested tree where the table is stored at the second level
-		return dict(foo=dict(bar=table))
+    def make_custom_tree(table):
+        # Return a nested tree where the table is stored at the second level
+        return dict(foo=dict(bar=table))
 
-	t = Table(dtype=[('a', 'f4'), ('b', 'i4'), ('c', 'S2')])
-	# Write the table to an **ASDF** file using a non-default key
-	t.write('foobar.asdf', make_tree=make_custom_tree)
+    t = Table(dtype=[('a', 'f4'), ('b', 'i4'), ('c', 'S2')])
+    # Write the table to an **ASDF** file using a non-default key
+    t.write('foobar.asdf', make_tree=make_custom_tree)
 
 Similarly, when reading an **ASDF** file, the user can pass a custom callback to
 locate the table within the **ASDF** tree. The option in this case is
@@ -87,8 +87,8 @@ locate the table within the **ASDF** tree. The option in this case is
 `dict` representing the **ASDF** tree, and it should return a
 `~astropy.table.Table` object::
 
-	def find_table(tree):
-		# This returns the Table that was stored by the example above
-		return tree['foo']['bar']
+    def find_table(tree):
+        # This returns the Table that was stored by the example above
+        return tree['foo']['bar']
 
-	foo = Table.read('foobar.asdf', find_table=find_table)
+    foo = Table.read('foobar.asdf', find_table=find_table)

--- a/docs/asdf-astropy/table.rst
+++ b/docs/asdf-astropy/table.rst
@@ -1,24 +1,24 @@
 .. _table:
 
-*************************
-Using ASDF with Table I/O
-*************************
+*****************************
+Using **ASDF** with Table I/O
+*****************************
 
-ASDF provides readers and writers for `~astropy.table.Table` using the
-:ref:`table_io`. This makes it convenient to read and write ASDF files with
+**ASDF** provides readers and writers for `~astropy.table.Table` using the
+:ref:`table_io`. This makes it convenient to read and write **ASDF** files with
 `~astropy.table.Table` data.
 
 Basic Usage
 ===========
 
-Given a table, it is possible to write it out to an ASDF file::
+Given a table, it is possible to write it out to an **ASDF** file::
 
-    from astropy.table import Table
+	from astropy.table import Table
 
-    # Create a simple table
-    t = Table(dtype=[('a', 'f4'), ('b', 'i4'), ('c', 'S2')])
-    # Write the table to an ASDF file
-    t.write('table.asdf')
+	# Create a simple table
+	t = Table(dtype=[('a', 'f4'), ('b', 'i4'), ('c', 'S2')])
+	# Write the table to an **ASDF** file
+	t.write('table.asdf')
 
 The I/O registry automatically selects the appropriate writer function to use
 based on the ``.asdf`` extension of the output file.
@@ -26,7 +26,7 @@ based on the ``.asdf`` extension of the output file.
 Reading a file generated in this way is also possible using
 `~astropy.table.Table.read`::
 
-    t2 = Table.read('table.asdf')
+	t2 = Table.read('table.asdf')
 
 The I/O registry automatically selects the appropriate reader function based on
 the extension of the input file.
@@ -34,61 +34,61 @@ the extension of the input file.
 In the case of both reading and writing, if the file extension is not ``.asdf``
 it is possible to explicitly specify the reader/writer function to be used::
 
-    t3 = Table.read('table.zxcv', format='asdf')
+	t3 = Table.read('table.zxcv', format='asdf')
 
 Advanced Usage
 ^^^^^^^^^^^^^^
 
-The fundamental ASDF data structure is the tree, which is a nested
+The fundamental **ASDF** data structure is the tree, which is a nested
 combination of basic data structures (see :ref:`asdf:data-model` for a more
 detailed description). At the top level, the tree is a `dict`.
 
 The consequence of this is that a `~astropy.table.Table` object (or any object,
-for that matter) can be stored at any arbitrary location within an ASDF tree.
+for that matter) can be stored at any arbitrary location within an **ASDF** tree.
 The basic writer use case described above stores the given
 `~astropy.table.Table` at the top of the tree using a default key. The basic
 reader case assumes that a `~astropy.table.Table` is stored in the same place.
 
 However, it may sometimes be useful for users to specify a different top-level
 key to be used for storage and retrieval of a `~astropy.table.Table` from an
-ASDF file. For this reason, the ASDF I/O interface provides ``data_key`` as an
+**ASDF** file. For this reason, the **ASDF** I/O interface provides ``data_key`` as an
 optional keyword when writing and reading::
 
-    from astropy.table import Table
+	from astropy.table import Table
 
-    t = Table(dtype=[('a', 'f4'), ('b', 'i4'), ('c', 'S2')])
-    # Write the table to an ASDF file using a non-default key
-    t.write('foo.asdf', data_key='foo')
+	t = Table(dtype=[('a', 'f4'), ('b', 'i4'), ('c', 'S2')])
+	# Write the table to an asdf file using a non-default key
+	t.write('foo.asdf', data_key='foo')
 
 A `~astropy.table.Table` stored using a custom data key can be retrieved by
 passing the same argument to `~astropy.table.Table.read`::
 
-    foo = Table.read('foo.asdf', data_key='foo')
+	foo = Table.read('foo.asdf', data_key='foo')
 
 The ``data_key`` option only applies to `~astropy.table.Table` objects that are
-stored at the top of the ASDF tree. For full generality, users may pass a
-callback when writing or reading ASDF files to define precisely where the
+stored at the top of the **ASDF** tree. For full generality, users may pass a
+callback when writing or reading **ASDF** files to define precisely where the
 `~astropy.table.Table` object should be placed in the tree. The option for the
 write case is ``make_tree``. The function callback should accept exactly one
 argument, which is the `~astropy.table.Table` object, and should return a
 `dict` representing the tree to be stored::
 
-    def make_custom_tree(table):
-        # Return a nested tree where the table is stored at the second level
-        return dict(foo=dict(bar=table))
+	def make_custom_tree(table):
+		# Return a nested tree where the table is stored at the second level
+		return dict(foo=dict(bar=table))
 
-    t = Table(dtype=[('a', 'f4'), ('b', 'i4'), ('c', 'S2')])
-    # Write the table to an ASDF file using a non-default key
-    t.write('foobar.asdf', make_tree=make_custom_tree)
+	t = Table(dtype=[('a', 'f4'), ('b', 'i4'), ('c', 'S2')])
+	# Write the table to an **ASDF** file using a non-default key
+	t.write('foobar.asdf', make_tree=make_custom_tree)
 
-Similarly, when reading an ASDF file, the user can pass a custom callback to
-locate the table within the ASDF tree. The option in this case is
+Similarly, when reading an **ASDF** file, the user can pass a custom callback to
+locate the table within the **ASDF** tree. The option in this case is
 ``find_table``. The callback should accept exactly one argument, which is an
-`dict` representing the ASDF tree, and it should return a
+`dict` representing the **ASDF** tree, and it should return a
 `~astropy.table.Table` object::
 
-    def find_table(tree):
-        # This returns the Table that was stored by the example above
-        return tree['foo']['bar']
+	def find_table(tree):
+		# This returns the Table that was stored by the example above
+		return tree['foo']['bar']
 
-    foo = Table.read('foobar.asdf', find_table=find_table)
+	foo = Table.read('foobar.asdf', find_table=find_table)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,6 +54,10 @@ highlight_language = "python3"
 # If your documentation needs a minimal Sphinx version, state it here.
 needs_sphinx = "1.7"
 
+intersphinx_mapping["astropy"] = ("http://docs.astropy.org/en/stable/", None)
+intersphinx_mapping["asdf"] = ("https://asdf.readthedocs.io/en/latest/", None)
+intersphinx_mapping["asdf-standard"] = ("https://asdf-standard.readthedocs.io/en/latest/", None)
+
 # To perform a Sphinx version check that needs to be more specific than
 # major.minor, call `check_sphinx_version("x.y.z")` here.
 # check_sphinx_version("1.2.1")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,7 +54,6 @@ highlight_language = "python3"
 # If your documentation needs a minimal Sphinx version, state it here.
 needs_sphinx = "1.7"
 
-intersphinx_mapping["astropy"] = ("http://docs.astropy.org/en/stable/", None)
 intersphinx_mapping["asdf"] = ("https://asdf.readthedocs.io/en/latest/", None)
 intersphinx_mapping["asdf-standard"] = ("https://asdf-standard.readthedocs.io/en/latest/", None)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,9 +14,8 @@ package has been designed to automatically detect the presence of tags defined b
 packages like **asdf-astropy** and automatically make use of that package's support
 infrastructure to operate correctly.
 
-Documentation on the ASDF Standard can be found `here
-<https://asdf-standard.readthedocs.io>`__. Documentation on the ASDF Python
-library can be found `here <https://asdf.readthedocs.io>`__.
+Documentation on the ASDF Standard can be found :ref:`here <asdf-standard:asdf-standard>`.
+Documentation on the ASDF Python library can be found :ref:`here <asdf:asdf>`.
 
 
 Getting Started

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,7 @@ Getting Started
 
   asdf-astropy/install.rst
   asdf-astropy/quickstart.rst
+  asdf-astropy/migrating.rst
 
 Using asdf-astropy
 ==================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,20 +22,20 @@ Getting Started
 ===============
 
 .. toctree::
-  :maxdepth: 2
+    :maxdepth: 2
 
-  asdf-astropy/install.rst
-  asdf-astropy/quickstart.rst
-  asdf-astropy/migrating.rst
+    asdf-astropy/install.rst
+    asdf-astropy/quickstart.rst
+    asdf-astropy/migrating.rst
 
 Using **asdf-astropy**
 ======================
 
 .. toctree::
-  :maxdepth: 2
+    :maxdepth: 2
 
-  asdf-astropy/table.rst
-  asdf-astropy/details.rst
-  asdf-astropy/example.rst
-  asdf-astropy/manifest.rst
-  asdf-astropy/schemas.rst
+    asdf-astropy/table.rst
+    asdf-astropy/details.rst
+    asdf-astropy/example.rst
+    asdf-astropy/manifest.rst
+    asdf-astropy/schemas.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,21 +1,21 @@
 .. _asdf-astropy:
 
-************
-asdf-astropy
-************
+**************************************
+The **asdf-astropy** Extension Package
+**************************************
 
-The **asdf-astropy** package contains code that is used to serialize ``astropy``
-types so that they can be represented and stored using the Advanced Scientific
-Data Format (ASDF).
+The **asdf-astropy** package contains code that is used to serialize **astropy**
+objects so that they can be represented and stored using the Advanced Scientific
+Data Format (**ASDF**).
 
 If **asdf-astropy** is installed, no further configuration is required in order
-to process ASDF files that contain **astropy** types. Note that the **asdf**
+to process **ASDF** files that contain **astropy** objects. Note that the **ASDF**
 package has been designed to automatically detect the presence of tags defined by
 packages like **asdf-astropy** and automatically make use of that package's support
 infrastructure to operate correctly.
 
-Documentation on the ASDF Standard can be found :ref:`here <asdf-standard:asdf-standard>`.
-Documentation on the ASDF Python library can be found :ref:`here <asdf:asdf>`.
+Documentation on the **ASDF Standard** can be found :ref:`here <asdf-standard:asdf-standard>`.
+Documentation on the **ASDF** Python library can be found :ref:`here <asdf:asdf>`.
 
 
 Getting Started
@@ -28,8 +28,8 @@ Getting Started
   asdf-astropy/quickstart.rst
   asdf-astropy/migrating.rst
 
-Using asdf-astropy
-==================
+Using **asdf-astropy**
+======================
 
 .. toctree::
   :maxdepth: 2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,7 @@ Getting Started
   :maxdepth: 2
 
   asdf-astropy/install.rst
+  asdf-astropy/quickstart.rst
 
 Using asdf-astropy
 ==================

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ github_project = astropy/asdf-astropy
 [options]
 zip_safe = True
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.8
 setup_requires = setuptools_scm
 install_requires =
     #astropy @ git+https://github.com/astropy/astropy


### PR DESCRIPTION
This PR is to address the issues found in the astropy coordinated package review, see: https://github.com/astropy/astropy.github.com/pull/490#issuecomment-1132239666

- Fixes #75 and Fixes #76 by properly setting minimum python version to 3.8
- Fixes #72 by adding a small quickstart guide
- Fixes #74 by adding notes about the transition of `astropy.io.misc.asdf` to this package