### PR TITLE
Apply pyupgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,13 @@ repos:
   - id: end-of-file-fixer
   - id: trailing-whitespace
 
+- repo: https://github.com/asottile/pyupgrade
+  rev: v2.34.0
+  hooks:
+    - id: pyupgrade
+      args: ["--py38-plus"]
+      exclude: "asdf/extern/.*|docs/.*"
+
 - repo: https://github.com/pycqa/isort
   rev: 5.10.1
   hooks:

--- a/asdf_astropy/converters/transform/compound.py
+++ b/asdf_astropy/converters/transform/compound.py
@@ -72,11 +72,11 @@ class CompoundConverter(TransformConverterBase):
 
         left = node["forward"][0]
         if not isinstance(left, Model):
-            raise TypeError("Unknown model type '{0}'".format(node["forward"][0]._tag))
+            raise TypeError("Unknown model type '{}'".format(node["forward"][0]._tag))
 
         right = node["forward"][1]
         if not isinstance(right, Model) and not (oper == "fix_inputs" and isinstance(right, dict)):
-            raise TypeError("Unknown model type '{0}'".format(node["forward"][1]._tag))
+            raise TypeError("Unknown model type '{}'".format(node["forward"][1]._tag))
 
         if oper == "fix_inputs":
             right = dict(zip(right["keys"], right["values"]))


### PR DESCRIPTION
Applies [`pyupgrade`](https://github.com/asottile/pyupgrade) to asdf-astropy and adds it to the pre-commit hooks. `pyupgrade` is a tool to automatically update the older python syntax to the newer more preferred syntax.