### PR TITLE
Update from autoflake8 to autoflake

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
 - repo: https://github.com/PyCQA/autoflake
   rev: v1.5.3
   hooks:
-  -  id: autoflake
+  - id: autoflake
 
 - repo: https://github.com/pycqa/isort
   rev: 5.10.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,10 +21,10 @@ repos:
     - id: pyupgrade
       args: ["--py38-plus"]
 
-- repo: https://github.com/fsouza/autoflake8
-  rev: v0.4.0
+- repo: https://github.com/PyCQA/autoflake
+  rev: v1.5.3
   hooks:
-  - id: autoflake8
+  -  id: autoflake
 
 - repo: https://github.com/pycqa/isort
   rev: 5.10.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,3 +129,8 @@ force-exclude = '''
 profile = "black"
 filter_files = true
 line_length = 120
+
+[tool.autoflake]
+remove-all-unused-imports = true
+ignore-init-module-imports = true
+remove-unused-variables = true


### PR DESCRIPTION
In https://github.com/asdf-format/asdf-transform-schemas/pull/69#discussion_r967744284, it was pointed out that autoflake8 was recently archived in favor of autoflake. This PR makes the update here.