### PR TITLE
Update the extensions to use the new `asdf-time-schemas` manifest

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@
 
 - Update citations. [#111]
 - Switch to using ``pyproject.toml`` for package configuration. [#106]
+- Add support for ``asdf-fits-schemas`` package. [#121]
 
 0.2.2 (2022-08-22)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@
 - Update citations. [#111]
 - Switch to using ``pyproject.toml`` for package configuration. [#106]
 - Add support for ``asdf-fits-schemas`` package. [#121]
+- Add support for ``asdf-time-schemas`` package. [#122]
 
 0.2.2 (2022-08-22)
 ------------------

--- a/asdf_astropy/extensions.py
+++ b/asdf_astropy/extensions.py
@@ -496,6 +496,9 @@ ASDF_CONVERTERS = [
 
 ASDF_MANIFEST_URIS = [
     "asdf://asdf-format.org/fits/manifests/fits-1.0.0",
+    "asdf://asdf-format.org/time/manifests/time-1.0.0",
+    "asdf://asdf-format.org/time/manifests/time-1.1.0",
+    "asdf://asdf-format.org/time/manifests/time-1.2.0",
 ]
 
 

--- a/asdf_astropy/extensions.py
+++ b/asdf_astropy/extensions.py
@@ -479,11 +479,8 @@ ASTROPY_EXTENSION = ManifestExtension.from_uri(
     converters=ASTROPY_CONVERTERS,
 )
 
-# These tags are part of the ASDF Standard,
-# but we want to override serialization here so that users can
-# work with nice astropy objects for those entities.
 
-CORE_CONVERTERS = [
+ASDF_CONVERTERS = [
     QuantityConverter(),
     TimeConverter(),
     UnitConverter(),
@@ -491,6 +488,23 @@ CORE_CONVERTERS = [
     AsdfTableConverter(),
     AsdfFitsConverter(),
 ]
+
+# These tags are part of secondary schema packages, which provide backwards compatibility
+# with older releases of ASDF standard. We want to override the standard serialization
+# when possible so that users can work directly with the nice astropy object.
+
+
+ASDF_MANIFEST_URIS = [
+    "asdf://asdf-format.org/fits/manifests/fits-1.0.0",
+]
+
+
+ASDF_EXTENSIONS = [ManifestExtension.from_uri(uri, converters=ASDF_CONVERTERS) for uri in ASDF_MANIFEST_URIS]
+
+
+# For backwards compatibility these tags are part of older ASDF standard releases,
+# but we want to override serialization here so that users can
+# work with nice astropy objects for those entities.
 
 
 CORE_MANIFEST_URIS = [
@@ -504,4 +518,4 @@ CORE_MANIFEST_URIS = [
 ]
 
 
-CORE_EXTENSIONS = [ManifestExtension.from_uri(u, converters=CORE_CONVERTERS) for u in CORE_MANIFEST_URIS]
+CORE_EXTENSIONS = [ManifestExtension.from_uri(u, converters=ASDF_CONVERTERS) for u in CORE_MANIFEST_URIS]

--- a/asdf_astropy/integration.py
+++ b/asdf_astropy/integration.py
@@ -43,5 +43,6 @@ def get_extensions():
     return (
         [extensions.ASTROPY_EXTENSION, extensions.COORDINATES_EXTENSION]
         + extensions.TRANSFORM_EXTENSIONS
+        + extensions.ASDF_EXTENSIONS
         + extensions.CORE_EXTENSIONS
     )


### PR DESCRIPTION
Updates the extensions so that the new `asdf-time-schemas` will function properly with the converters provided by `asdf-astropy`.

This PR depends on #121, and will require `asdf-time-schemas` to be added as a dependency before it is merged