### PR TITLE
Bugfix for `memmap` not working with `Quantity`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@
 
 - Update citations. [#111]
 - Switch to using ``pyproject.toml`` for package configuration. [#106]
+- Fix bug with ``memmap`` of ``Quantity`` objects. [#125]
 
 0.2.2 (2022-08-22)
 ------------------

--- a/asdf_astropy/converters/unit/quantity.py
+++ b/asdf_astropy/converters/unit/quantity.py
@@ -27,4 +27,4 @@ class QuantityConverter(Converter):
             # and documentation.
             value = value._make_array()
 
-        return Quantity(value, unit=node["unit"])
+        return Quantity(value, unit=node["unit"], copy=False)


### PR DESCRIPTION
Based on the discussion in astropy/astropy#13864, I found that we need to add the `copy=False` flag to the array constructor and arrange for a more complicated test for `memmap` than we normally require.

resolves astropy/astropy#13864