### PR TITLE
Bugfix for `Quantity.dtype`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@
 - Fix bug with ``memmap`` of ``Quantity`` objects. [#125]
 - Drop support for ``numpy-1.18``. [#116]
 - Fix bug with ``str`` representations of ``astropy.time`` objects. [#132]
+- Fix bug in preserving the ``dtype`` of ``Quantity`` objects. [#131]
 
 0.2.2 (2022-08-22)
 ------------------

--- a/asdf_astropy/converters/unit/quantity.py
+++ b/asdf_astropy/converters/unit/quantity.py
@@ -13,20 +13,25 @@ class QuantityConverter(Converter):
     ]
 
     def to_yaml_tree(self, obj, tag, ctx):
-        return {
+        node = {
             "value": obj.value,
             "unit": obj.unit,
         }
+
+        if obj.isscalar:
+            node["datatype"] = obj.dtype.name
+
+        return node
 
     def from_yaml_tree(self, node, tag, ctx):
         from astropy.units import Quantity
 
         value = node["value"]
-        kwargs = {}
+        dtype = node.get("datatype", None)
         if isinstance(value, NDArrayType):
             # TODO: Why doesn't NDArrayType work?  This needs some research
             # and documentation.
             value = value._make_array()
-            kwargs["dtype"] = value.dtype
+            dtype = value.dtype
 
-        return Quantity(value, unit=node["unit"], copy=False, **kwargs)
+        return Quantity(value, unit=node["unit"], copy=False, dtype=dtype)

--- a/asdf_astropy/converters/unit/quantity.py
+++ b/asdf_astropy/converters/unit/quantity.py
@@ -22,9 +22,11 @@ class QuantityConverter(Converter):
         from astropy.units import Quantity
 
         value = node["value"]
+        kwargs = {}
         if isinstance(value, NDArrayType):
             # TODO: Why doesn't NDArrayType work?  This needs some research
             # and documentation.
             value = value._make_array()
+            kwargs["dtype"] = value.dtype
 
-        return Quantity(value, unit=node["unit"], copy=False)
+        return Quantity(value, unit=node["unit"], copy=False, **kwargs)

--- a/asdf_astropy/converters/unit/tests/test_quantity.py
+++ b/asdf_astropy/converters/unit/tests/test_quantity.py
@@ -11,6 +11,8 @@ def create_quantities():
     return [
         # Scalar:
         Quantity(2.71828, units.kpc),
+        # Non-float scalar:
+        Quantity(7, units.K, dtype=np.int32),
         # Single element array:
         Quantity([3.14159], units.kg),
         # Multiple element array:

--- a/asdf_astropy/converters/unit/tests/test_quantity.py
+++ b/asdf_astropy/converters/unit/tests/test_quantity.py
@@ -17,6 +17,8 @@ def create_quantities():
         Quantity([x * 2.3081 for x in range(10)], units.ampere),
         # Multiple dimension array:
         Quantity(np.arange(100, dtype=np.float64).reshape(5, 20), units.km),
+        # Non-float array:
+        Quantity(np.zeros((5, 5), dtype=np.uint16), units.cm, dtype=np.uint16),
     ]
 
 
@@ -28,6 +30,8 @@ def test_serialization(quantity, tmp_path):
         af.write_to(file_path)
 
     with asdf.open(file_path) as af:
+        assert (af["quantity"].value == quantity.value).all()
+        assert af["quantity"].dtype == quantity.dtype
         assert (af["quantity"] == quantity).all()
 
 


### PR DESCRIPTION
Bugfix so that the `dtype` of a `Quantity` object is preserved.

Fixes #130