### PR TITLE
Bugfix for time strings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@
 - Switch to using ``pyproject.toml`` for package configuration. [#106]
 - Fix bug with ``memmap`` of ``Quantity`` objects. [#125]
 - Drop support for ``numpy-1.18``. [#116]
+- Fix bug with ``str`` representations of ``astropy.time`` objects. [#132]
 
 0.2.2 (2022-08-22)
 ------------------

--- a/asdf_astropy/converters/time/tests/test_time.py
+++ b/asdf_astropy/converters/time/tests/test_time.py
@@ -138,12 +138,15 @@ def create_formats():
 
 @pytest.mark.parametrize("time", create_formats())
 def test_formats(time, tmp_path):
-    print(time)
+    if "jyear" in time.format:
+        atol = 1 * u.day
+    else:
+        atol = 1e-8 * u.day
+
     file_path = tmp_path / "test.asdf"
     with asdf.AsdfFile() as af:
         af["time"] = time
         af.write_to(file_path)
-
     with asdf.open(file_path) as af:
-        af["time"] == time
-        af["time"].format == time.format
+        assert af["time"].isclose(time, atol=atol)
+        assert af["time"].format == time.format

--- a/asdf_astropy/converters/time/time.py
+++ b/asdf_astropy/converters/time/time.py
@@ -35,11 +35,13 @@ class TimeConverter(Converter):
 
         node = {
             "value": obj.value,
-            "base_format": base_format,
         }
 
         if not guessable_format:
             node["format"] = asdf_format
+
+        if base_format != obj.format:
+            node["base_format"] = base_format
 
         if obj.scale != "utc":
             node["scale"] = obj.scale

--- a/asdf_astropy/converters/time/time.py
+++ b/asdf_astropy/converters/time/time.py
@@ -30,6 +30,9 @@ class TimeConverter(Converter):
         asdf_format = _ASTROPY_FORMAT_TO_ASDF_FORMAT.get(obj.format, obj.format)
         guessable_format = asdf_format in _GUESSABLE_FORMATS
 
+        if obj.scale == "utc" and guessable_format and obj.isscalar and base_format == obj.format:
+            return obj.value
+
         node = {
             "value": obj.value,
             "base_format": base_format,


### PR DESCRIPTION
This PR returns some pure string outputs from the time converter under some circumstances as requested in #128 reverting some of the changes in #86. With this PR:

- `iso`
- `jyear_str`
- `byear_str`
- `yday`

will be written purely as strings. Before #86 the:

- `isot`
- `jyear`
- `byear`

formats would also be written as pure strings; however, these will no round-trip the format as they would be deserialize as `iso`, `jyear_str`, and `byear_str` formats respectively.

Fixes #128