### PR TITLE
Start using codespell

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,14 @@ repos:
     - id: rst-inline-touching-normal
     - id: text-unicode-replacement-char
 
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.2.2
+  hooks:
+    - id: codespell
+      args: ["--write-changes"]
+      additional_dependencies:
+        - tomli
+
 - repo: https://github.com/asottile/pyupgrade
   rev: v3.3.0
   hooks:

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ ASDF serialization support for astropy
 This package includes plugins that provide ASDF serialization support for astropy
 objects.  The plugins are automatically enabled when the package is installed.
 
-The plugins in this package supercede those in the ``astropy.io.misc.asdf`` module;
+The plugins in this package supersede those in the ``astropy.io.misc.asdf`` module;
 when this package is installed, the astropy plugins will be ignored.  The
 ``astropy.io.misc.asdf`` module will be removed in a future version of astropy.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,3 +137,6 @@ line_length = 120
 [tool.ruff]
 line-length = 120
 extend-exclude = ["docs/*"]
+
+[tool.codespell]
+skip="*.pdf,*.fits,*.asdf,*.egg-info,.tox,build,./tags,.git,./docs/_build"


### PR DESCRIPTION
Similar to asdf-format/asdf#1267, this PR introduces using [codespell](https://github.com/codespell-project/codespell) to `asdf-astropy`.