### PR TITLE
Fix failing CI and clean up tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,7 @@ envlist =
     py38-test-devdeps
     py38-cov
     py{39,}-test-numpy{119,120,121,122}
-    build_docs
-    codestyle
     py38-astropylts
-    bandit
 requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
@@ -40,9 +37,6 @@ deps =
 
     devdeps: -rrequirements-dev.txt
 
-    py310: git+https://github.com/pytest-dev/pytest
-
-# The following indicates which extras_require from setup.cfg will be installed
 extras =
     test
     alldeps: all
@@ -52,40 +46,3 @@ commands =
     pip freeze
     !cov: pytest {posargs}
     cov: pytest --cov-report xml --cov asdf_astropy {posargs}
-
-[testenv:build_docs]
-changedir = docs
-description = invoke sphinx-build to build the HTML docs
-extras = docs
-commands =
-    pip freeze
-    sphinx-build -W . _build/html
-
-[testenv:twine]
-usedevelop= false
-deps=
-    twine
-commands=
-    twine check {distdir}/*
-
-[testenv:codestyle]
-skip_install = true
-description = Run all style and file checks with pre-commit
-deps =
-    pre-commit
-commands =
-    pre-commit install-hooks
-    pre-commit run {posargs:--color always --all-files --show-diff-on-failure}
-
-[testenv:style]
-deps=
-    flake8
-commands=
-    flake8 --count
-
-[testenv:bandit]
-deps=
-    bandit
-    toml
-commands=
-    bandit -c bandit.yaml -r .

--- a/tox.ini
+++ b/tox.ini
@@ -14,18 +14,6 @@ requires =
 isolated_build = true
 
 [testenv]
-
-# Pass through the following environment variables which may be needed for the CI
-passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI TRAVIS
-
-# tox environments are constructed with so-called 'factors' (or terms)
-# separated by hyphens, e.g. test-devdeps-cov. Lines below starting with factor:
-# will only take effect if that factor is included in the environment name. To
-# see a list of example environments that can be run, along with a description,
-# run:
-#
-#     tox -l -v
-#
 description =
     run tests
     alldeps: with all optional dependencies


### PR DESCRIPTION
Currently the CI is failing: https://github.com/astropy/asdf-astropy/actions/runs/3673136901.

This appears to be due to some old and unnecessary settings in the `tox.ini` file. This PR removes that setting and cleans out the old unused tox environments.