### PR TITLE
Add oldest testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,37 @@ jobs:
         - linux: py310-test
         - macos: py39-test
         - windows: py39-test
+
+  dev:
+    needs: [core, asdf-schemas]
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    with:
+      cache-path: ~/.cache/pip
+      cache-key: pip-${{ needs.setup.outputs.requirements-hash }}
+      cache-restore-keys: |
+        pip-
+      # Any env name which does not start with `pyXY` will use this Python version.
+      default_python: '3.9'
+      envs: |
+        - linux: py38-test-devdeps
+        - linux: py39-test-devdeps
+        - linux: py310-test-devdeps
         - linux: py311-test-devdeps
-          python-version: 3.11.0
+
+  oldest:
+    needs: [core, asdf-schemas]
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    with:
+      cache-path: ~/.cache/pip
+      cache-key: pip-${{ needs.setup.outputs.requirements-hash }}
+      cache-restore-keys: |
+        pip-
+      # Any env name which does not start with `pyXY` will use this Python version.
+      default_python: '3.9'
+      envs: |
+        - linux: py38-test-oldestdeps-cov
+        - linux: py39-test-oldestdeps-cov
+      coverage: codecov
 
   numpy:
     needs: [core, asdf-schemas]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+0.4.0 (unreleased)
+------------------
+
+- Update pins for ``asdf``, ``asdf-coordinates-schemas``, ``numpy``, and ``packaging``. [#164]
+
 0.3.0 (2022-11-29)
 ------------------
 

--- a/asdf_astropy/converters/transform/tests/test_transform.py
+++ b/asdf_astropy/converters/transform/tests/test_transform.py
@@ -834,11 +834,15 @@ model: !transform/concatenate-1.2.0
         else:
             asdf.open(buff)
     else:
-        with pytest.raises(
-            RuntimeError,
-            match=r"Deserializing ignored elements of a compound bounding box is only supported for astropy 5.1+.",
-        ):
-            asdf.open(buff)
+        if not minversion("asdf_transform_schemas", "0.2.2", inclusive=False):
+            with pytest.raises(TypeError, match=r"Cannot form bounding_box from: *"):
+                asdf.open(buff)
+        else:
+            with pytest.raises(
+                RuntimeError,
+                match=r"Deserializing ignored elements of a compound bounding box is only supported for astropy 5.1+.",
+            ):
+                asdf.open(buff)
 
 
 def test_serialize_bbox(tmpdir):
@@ -860,8 +864,18 @@ def test_serialize_bbox(tmpdir):
         bbox = ModelBoundingBox({"x": (1, 2)}, mdl, ignored=["y"])
         mdl._user_bounding_box = bbox
 
-        with pytest.raises(RuntimeError, match=r"Bounding box ignored arguments are only supported by astropy 5.1+"):
-            assert_model_roundtrip(mdl, tmpdir)
+        if minversion("asdf_transform_schemas", "0.2.2", inclusive=False):
+            with pytest.raises(
+                RuntimeError,
+                match=r"Bounding box ignored arguments are only supported by astropy 5.1+",
+            ):
+                assert_model_roundtrip(mdl, tmpdir)
+        else:
+            with pytest.raises(
+                RuntimeError,
+                match=r"asdf-transform-schemas > 0.2.2 in order to serialize a bounding_box with ignored",
+            ):
+                assert_model_roundtrip(mdl, tmpdir)
 
 
 def test_serialize_cbbox(tmpdir):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,12 +15,12 @@ classifiers = [
 ]
 dependencies = [
     'astropy >=5.0.4',
-    'asdf >=2.8.0',
-    'numpy',
-    'asdf-coordinates-schemas',
+    'asdf >=2.13.0',
+    'numpy >=1.20',
+    'asdf-coordinates-schemas >=0.1.0',
     'asdf-transform-schemas >=0.2.2',
     'importlib_resources >=3; python_version <"3.9"',
-    'packaging >=16.0',
+    'packaging >=19.0',
 ]
 dynamic = ['version']
 

--- a/tox.ini
+++ b/tox.ini
@@ -36,14 +36,21 @@ deps =
     transformlts: asdf-transform-schemas==0.2.*
 
     devdeps: -rrequirements-dev.txt
+    oldestdeps: minimum_dependencies
 
 extras =
     test
     alldeps: all
-
-commands =
+commands_pre=
     devdeps: pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
+
+    # Generate `requiremments-min.txt`
+    oldestdeps: minimum_dependencies asdf-astropy --filename {envtmpdir}/requirements-min.txt
+    # Force install everything from `requirements-min.txt`
+    oldestdeps: pip install -r {envtmpdir}/requirements-min.txt
+
     pip freeze
+commands =
     !cov: pytest {posargs}
     cov: pytest --cov-report xml --cov asdf_astropy {posargs}
 


### PR DESCRIPTION
Adds testing for the oldest declared dependencies of `asdf-astropy`.