### PR TITLE
Move helper functions to `asdf_astropy.testing.helpers`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 - Update pins for ``asdf``, ``asdf-coordinates-schemas``, ``numpy``, and ``packaging``. [#164]
 - Add serialization support for non-VOunits. [#142]
 - Add serialization support for ``MagUnit`` based units. [#146]
+- Document and add ``assert_model_roundtrip`` and ``assert_table_roundtrip`` to
+  ``asdf_astropy.testing.helpers``. [#170]
 
 0.3.0 (2022-11-29)
 ------------------

--- a/asdf_astropy/converters/table/tests/test_table.py
+++ b/asdf_astropy/converters/table/tests/test_table.py
@@ -43,6 +43,28 @@ def assert_table_roundtrip(table, tmp_path):
     return helpers.assert_table_roundtrip(table, tmp_path)
 
 
+def test_deprecations(tmp_path):
+    rows = [(1, 2.0, "x"), (4, 5.0, "y"), (5, 8.2, "z")]
+
+    table = Table(rows=rows, names=("a", "b", "c"), dtype=("i4", "f8", "S1"))
+    table.columns["a"].description = "RA"
+    table.columns["a"].unit = "degree"
+    table.columns["a"].meta = {"foo": "bar"}
+    table.columns["c"].description = "Some description of some sort"
+
+    # Test assert_description_equal deprecation
+    with pytest.warns(DeprecationWarning, match=".*assert_description_equal.*"):
+        assert_description_equal("a", "a")
+
+    # Test assert_table_equal deprecation
+    with pytest.warns(DeprecationWarning, match=".*assert_table_equal.*"):
+        assert_table_equal(table, table)
+
+    # Test assert_table_roundtrip deprecation
+    with pytest.warns(DeprecationWarning, match=".*assert_table_roundtrip.*"):
+        assert_table_roundtrip(table, tmp_path)
+
+
 def test_table(tmp_path):
     rows = [(1, 2.0, "x"), (4, 5.0, "y"), (5, 8.2, "z")]
 

--- a/asdf_astropy/converters/table/tests/test_table.py
+++ b/asdf_astropy/converters/table/tests/test_table.py
@@ -1,64 +1,46 @@
+import warnings
+
 import asdf
 import astropy.units as u
 import numpy as np
 import pytest
 from asdf.testing.helpers import yaml_to_asdf
 from astropy.coordinates import EarthLocation, SkyCoord
-from astropy.table import Column, MaskedColumn, NdarrayMixin, QTable, Table
+from astropy.table import NdarrayMixin, QTable, Table
 from astropy.time import Time, TimeDelta
 from numpy.testing import assert_array_equal
 
-from asdf_astropy.testing.helpers import (
-    assert_earth_location_equal,
-    assert_sky_coord_equal,
-    assert_time_delta_equal,
-    assert_time_equal,
-)
+from asdf_astropy.testing import helpers
 
 
 def assert_description_equal(a, b):
-    if a in ("", None) and b in ("", None):
-        return
+    message = (
+        "asdf_astropy.converters.table.tests.test_table.assert_description_equal is deprecated."
+        "Use asdf_astropy.testing.helpers.assert_description_equal instead."
+    )
+    warnings.warn(message, DeprecationWarning)
 
-    assert a == b
+    return helpers.assert_description_equal(a, b)
 
 
 def assert_table_equal(a, b):
-    assert type(a) == type(b)
-    assert a.meta == b.meta
+    message = (
+        "asdf_astropy.converters.table.tests.test_table.assert_table_equal is deprecated."
+        "Use asdf_astropy.testing.helpers.assert_table_equal instead."
+    )
+    warnings.warn(message, DeprecationWarning)
 
-    assert len(a) == len(b)
-    for row_a, row_b in zip(a, b):
-        assert_array_equal(row_a, row_b)
-
-    assert a.colnames == b.colnames
-    for column_name in a.colnames:
-        col_a = a[column_name]
-        col_b = b[column_name]
-        if isinstance(col_a, (Column, MaskedColumn)) and isinstance(col_b, (Column, MaskedColumn)):
-            assert_description_equal(col_a.description, col_b.description)
-            assert col_a.unit == col_b.unit
-            assert col_a.meta == col_b.meta
-            assert_array_equal(col_a.data, col_b.data)
-            assert_array_equal(
-                getattr(col_a, "mask", [False] * len(col_a)),
-                getattr(col_b, "mask", [False] * len(col_b)),
-            )
+    return helpers.assert_table_equal(a, b)
 
 
 def assert_table_roundtrip(table, tmp_path):
-    """
-    Assert that a table can be written to an ASDF file and read back
-    in without losing any of its essential properties.
-    """
-    file_path = tmp_path / "testable.asdf"
+    message = (
+        "asdf_astropy.converters.table.tests.test_table.assert_table_roundtrip is deprecated."
+        "Use asdf_astropy.testing.helpers.assert_table_roundtrip instead."
+    )
+    warnings.warn(message, DeprecationWarning)
 
-    with asdf.AsdfFile({"table": table}) as af:
-        af.write_to(file_path)
-
-    with asdf.open(file_path) as af:
-        assert_table_equal(table, af["table"])
-        return af["table"]
+    return helpers.assert_table_roundtrip(table, tmp_path)
 
 
 def test_table(tmp_path):
@@ -70,7 +52,7 @@ def test_table(tmp_path):
     table.columns["a"].meta = {"foo": "bar"}
     table.columns["c"].description = "Some description of some sort"
 
-    assert_table_roundtrip(table, tmp_path)
+    helpers.assert_table_roundtrip(table, tmp_path)
 
 
 def test_array_columns(tmp_path):
@@ -81,7 +63,7 @@ def test_array_columns(tmp_path):
 
     table = Table(data, copy=False)
 
-    assert_table_roundtrip(table, tmp_path)
+    helpers.assert_table_roundtrip(table, tmp_path)
 
 
 def test_structured_array_columns(tmp_path):
@@ -92,7 +74,7 @@ def test_structured_array_columns(tmp_path):
 
     table = Table(rows, copy=False)
 
-    assert_table_roundtrip(table, tmp_path)
+    helpers.assert_table_roundtrip(table, tmp_path)
 
 
 def test_table_row_order(tmp_path):
@@ -104,7 +86,7 @@ def test_table_row_order(tmp_path):
     table.columns["a"].meta = {"foo": "bar"}
     table.columns["c"].description = "Some description of some sort"
 
-    assert_table_roundtrip(table, tmp_path)
+    helpers.assert_table_roundtrip(table, tmp_path)
 
 
 def test_table_inline(tmp_path):
@@ -117,7 +99,7 @@ def test_table_inline(tmp_path):
 
     with asdf.config_context() as config:
         config.array_inline_threshold = 64
-        assert_table_roundtrip(table, tmp_path)
+        helpers.assert_table_roundtrip(table, tmp_path)
 
 
 def test_mismatched_columns():
@@ -150,7 +132,7 @@ def test_masked_table(tmp_path):
     table.columns["a"].mask = [True, False, True]
     table.columns["c"].description = "Some description of some sort"
 
-    assert_table_roundtrip(table, tmp_path)
+    helpers.assert_table_roundtrip(table, tmp_path)
 
 
 def test_quantity_mixin(tmp_path):
@@ -159,7 +141,7 @@ def test_quantity_mixin(tmp_path):
     table["b"] = ["x", "y", "z"]
     table["c"] = [2.0, 5.0, 8.2] * u.m
 
-    assert_table_roundtrip(table, tmp_path)
+    helpers.assert_table_roundtrip(table, tmp_path)
 
 
 def test_time_mixin(tmp_path):
@@ -168,8 +150,8 @@ def test_time_mixin(tmp_path):
     table["b"] = ["x", "y"]
     table["c"] = Time(["2001-01-02T12:34:56", "2001-02-03T00:01:02"])
 
-    result = assert_table_roundtrip(table, tmp_path)
-    assert_time_equal(result["c"], table["c"])
+    result = helpers.assert_table_roundtrip(table, tmp_path)
+    helpers.assert_time_equal(result["c"], table["c"])
 
 
 def test_timedelta_mixin(tmp_path):
@@ -178,8 +160,8 @@ def test_timedelta_mixin(tmp_path):
     table["b"] = ["x", "y"]
     table["c"] = TimeDelta([1, 2] * u.day)
 
-    result = assert_table_roundtrip(table, tmp_path)
-    assert_time_delta_equal(result["c"], table["c"])
+    result = helpers.assert_table_roundtrip(table, tmp_path)
+    helpers.assert_time_delta_equal(result["c"], table["c"])
 
 
 def test_skycoord_mixin(tmp_path):
@@ -196,7 +178,7 @@ def test_skycoord_mixin(tmp_path):
         af.write_to(file_path)
 
     with asdf.open(file_path) as af:
-        assert_sky_coord_equal(af["table"]["c"], table["c"])
+        helpers.assert_sky_coord_equal(af["table"]["c"], table["c"])
 
 
 def test_earthlocation_mixin(tmp_path):
@@ -205,8 +187,8 @@ def test_earthlocation_mixin(tmp_path):
     table["b"] = ["x", "y"]
     table["c"] = EarthLocation(x=[1, 2] * u.km, y=[3, 4] * u.km, z=[5, 6] * u.km)
 
-    result = assert_table_roundtrip(table, tmp_path)
-    assert_earth_location_equal(result["c"], table["c"])
+    result = helpers.assert_table_roundtrip(table, tmp_path)
+    helpers.assert_earth_location_equal(result["c"], table["c"])
 
 
 def test_ndarray_mixin(tmp_path):
@@ -215,7 +197,7 @@ def test_ndarray_mixin(tmp_path):
     table["b"] = ["x", "y"]
     table["c"] = NdarrayMixin([5, 6])
 
-    assert_table_roundtrip(table, tmp_path)
+    helpers.assert_table_roundtrip(table, tmp_path)
 
 
 def test_asdf_table():

--- a/asdf_astropy/converters/transform/tests/test_transform.py
+++ b/asdf_astropy/converters/transform/tests/test_transform.py
@@ -37,6 +37,10 @@ def assert_model_roundtrip(model, tmp_path, version=None):
     return helpers.assert_model_roundtrip(model, tmp_path, version=version)
 
 
+@pytest.mark.skipif(
+    not minversion("asdf_transform_schemas", "0.2.2", inclusive=False),
+    reason="Schema not present until versions after asdf-transform-schemas 0.2.2",
+)
 def test_deprecations(tmp_path):
     # Test assert_bounding_box_roundtrip deprecation
     bbox = ModelBoundingBox((0, 1), astropy_models.Polynomial1D(1))

--- a/asdf_astropy/converters/transform/tests/test_transform.py
+++ b/asdf_astropy/converters/transform/tests/test_transform.py
@@ -34,7 +34,19 @@ def assert_model_roundtrip(model, tmp_path, version=None):
     )
     warnings.warn(message, DeprecationWarning)
 
-    return helpers.assert_bounding_box_roundtrip(model, tmp_path, version=version)
+    return helpers.assert_model_roundtrip(model, tmp_path, version=version)
+
+
+def test_deprecations(tmp_path):
+    # Test assert_bounding_box_roundtrip deprecation
+    bbox = ModelBoundingBox((0, 1), astropy_models.Polynomial1D(1))
+    with pytest.warns(DeprecationWarning, match=".*assert_bounding_box_roundtrip.*"):
+        assert_bounding_box_roundtrip(bbox, tmp_path)
+
+    # Test assert_model_roundtrip deprecation
+    model = astropy_models.Gaussian2D()
+    with pytest.warns(DeprecationWarning, match=".*assert_model_roundtrip.*"):
+        assert_model_roundtrip(model, tmp_path)
 
 
 def create_bounding_boxes():

--- a/asdf_astropy/converters/transform/tests/test_transform.py
+++ b/asdf_astropy/converters/transform/tests/test_transform.py
@@ -1,5 +1,6 @@
 import itertools
 import unittest.mock as mk
+import warnings
 
 import asdf
 import astropy
@@ -13,21 +14,27 @@ from astropy.modeling.bounding_box import CompoundBoundingBox, ModelBoundingBox
 from astropy.utils import minversion
 
 from asdf_astropy import integration
-from asdf_astropy.testing.helpers import assert_model_equal
+from asdf_astropy.testing import helpers
 
 
 def assert_bounding_box_roundtrip(bounding_box, tmpdir, version=None):
-    """
-    Assert that a bounding_box can be written to an ASDF file and read back
-    in without losing any of its essential properties.
-    """
-    path = str(tmpdir / "test.asdf")
+    message = (
+        "asdf_astropy.converters.transforms.tests.test_transform.assert_bounding_box_round_trip is deprecated."
+        "Use asdf_astropy.testing.helpers.assert_bounding_box_roundtrip instead."
+    )
+    warnings.warn(message, DeprecationWarning)
 
-    with asdf.AsdfFile({"bounding_box": bounding_box}, version=version) as af:
-        af.write_to(path)
+    return helpers.assert_bounding_box_roundtrip(bounding_box, tmpdir, version=version)
 
-    with asdf.open(path) as af:
-        assert bounding_box == af["bounding_box"](bounding_box._model)
+
+def assert_model_roundtrip(model, tmpdir, version=None):
+    message = (
+        "asdf_astropy.converters.transforms.tests.test_transform.assert_model_round_trip is deprecated."
+        "Use asdf_astropy.testing.helpers.assert_model_roundtrip instead."
+    )
+    warnings.warn(message, DeprecationWarning)
+
+    return helpers.assert_bounding_box_roundtrip(model, tmpdir, version=version)
 
 
 def create_bounding_boxes():
@@ -82,22 +89,7 @@ def create_bounding_boxes():
     reason="Schema not present until versions after asdf-transform-schemas 0.2.2",
 )
 def test_round_trip_bounding_box(bbox, tmpdir):
-    assert_bounding_box_roundtrip(bbox, tmpdir)
-
-
-def assert_model_roundtrip(model, tmpdir, version=None):
-    """
-    Assert that a model can be written to an ASDF file and read back
-    in without losing any of its essential properties.
-    """
-    path = str(tmpdir / "test.asdf")
-
-    with asdf.AsdfFile({"model": model}, version=version) as af:
-        af.write_to(path)
-
-    with asdf.open(path) as af:
-        assert_model_equal(model, af["model"])
-        return af["model"]
+    helpers.assert_bounding_box_roundtrip(bbox, tmpdir)
 
 
 def create_single_models():  # noqa: PLR0915
@@ -480,7 +472,7 @@ if minversion("astropy", "5.1") and not minversion("asdf_transform_schemas", "0.
 
 @pytest.mark.parametrize("model", create_single_models())
 def test_single_model(tmpdir, model):
-    assert_model_roundtrip(model, tmpdir)
+    helpers.assert_model_roundtrip(model, tmpdir)
 
 
 def get_all_models():
@@ -521,11 +513,11 @@ def test_legacy_const(tmpdir):
         config.remove_extension("asdf://asdf-format.org/transform/extensions/transform-1.5.0")
 
         model = astropy_models.Const1D(amplitude=5.0)
-        assert_model_roundtrip(model, tmpdir, version="1.3.0")
+        helpers.assert_model_roundtrip(model, tmpdir, version="1.3.0")
 
         model = astropy_models.Const2D(amplitude=5.0)
         with pytest.raises(TypeError, match=r".* does not support models with > 1 dimension"):
-            assert_model_roundtrip(model, tmpdir, version="1.3.0")
+            helpers.assert_model_roundtrip(model, tmpdir, version="1.3.0")
 
 
 COMPOUND_OPERATORS = [
@@ -544,17 +536,17 @@ def test_compound_model(tmpdir, operator):
     left_model = astropy_models.Shift(5)
     right_model = astropy_models.Shift(-1)
     model = getattr(left_model, operator)(right_model)
-    result = assert_model_roundtrip(model, tmpdir)
-    assert_model_equal(result.left, left_model)
-    assert_model_equal(result.right, right_model)
+    result = helpers.assert_model_roundtrip(model, tmpdir)
+    helpers.assert_model_equal(result.left, left_model)
+    helpers.assert_model_equal(result.right, right_model)
     assert result.op == model.op
 
 
 def test_fix_inputs(tmpdir):
     model = astropy_models.Gaussian2D(1, 2, 3, 4, 5)
     fixed_model = astropy_models.fix_inputs(model, {"x": 2.5})
-    result = assert_model_roundtrip(fixed_model, tmpdir)
-    assert_model_equal(result.left, model)
+    result = helpers.assert_model_roundtrip(fixed_model, tmpdir)
+    helpers.assert_model_equal(result.left, model)
     assert result.right == fixed_model.right
     assert result.op == fixed_model.op
 
@@ -563,17 +555,17 @@ def test_units_mapping(tmpdir):
     # Basic mapping between units:
     model = astropy_models.UnitsMapping(((u.m, u.dimensionless_unscaled),))
     model.name = "foo"
-    result = assert_model_roundtrip(model, tmpdir)
+    result = helpers.assert_model_roundtrip(model, tmpdir)
     assert result.mapping == model.mapping
 
     # Remove units:
     model = astropy_models.UnitsMapping(((u.m, None),))
-    result = assert_model_roundtrip(model, tmpdir)
+    result = helpers.assert_model_roundtrip(model, tmpdir)
     assert result.mapping == model.mapping
 
     # Change a model to accept any units:
     model = astropy_models.UnitsMapping(((None, u.m),))
-    result = assert_model_roundtrip(model, tmpdir)
+    result = helpers.assert_model_roundtrip(model, tmpdir)
     assert result.mapping == model.mapping
 
     # With equivalencies:
@@ -581,7 +573,7 @@ def test_units_mapping(tmpdir):
         ((u.m, u.dimensionless_unscaled),),
         input_units_equivalencies={"x": u.equivalencies.spectral()},
     )
-    result = assert_model_roundtrip(model, tmpdir)
+    result = helpers.assert_model_roundtrip(model, tmpdir)
     assert result.mapping == model.mapping
 
     # Allow dimensionless on all inputs:
@@ -589,7 +581,7 @@ def test_units_mapping(tmpdir):
         ((u.m, u.dimensionless_unscaled), (u.s, u.Hz)),
         input_units_allow_dimensionless=True,
     )
-    result = assert_model_roundtrip(model, tmpdir)
+    result = helpers.assert_model_roundtrip(model, tmpdir)
     assert result.mapping == model.mapping
 
     # Allow dimensionless selectively:
@@ -597,7 +589,7 @@ def test_units_mapping(tmpdir):
         ((u.m, u.dimensionless_unscaled), (u.s, u.Hz)),
         input_units_allow_dimensionless={"x0": True, "x1": False},
     )
-    result = assert_model_roundtrip(model, tmpdir)
+    result = helpers.assert_model_roundtrip(model, tmpdir)
     assert result.mapping == model.mapping
 
 
@@ -612,7 +604,7 @@ def test_units_mapping(tmpdir):
     ],
 )
 def test_1d_polynomial_with_asdf_standard_version(tmpdir, standard_version, model):
-    result = assert_model_roundtrip(model, tmpdir, version=standard_version)
+    result = helpers.assert_model_roundtrip(model, tmpdir, version=standard_version)
     assert result.domain == model.domain
     assert result.window == model.window
 
@@ -647,7 +639,7 @@ def test_1d_polynomial_with_asdf_standard_version(tmpdir, standard_version, mode
     ],
 )
 def test_2d_polynomial_with_asdf_standard_version(tmpdir, standard_version, model):
-    result = assert_model_roundtrip(model, tmpdir, version=standard_version)
+    result = helpers.assert_model_roundtrip(model, tmpdir, version=standard_version)
     assert result.x_domain == model.x_domain
     assert result.y_domain == model.y_domain
     assert result.x_window == model.x_window
@@ -853,13 +845,13 @@ def test_serialize_bbox(tmpdir):
 
         bind_bounding_box(mdl, (1, 2), ignored="y")
         if minversion("asdf_transform_schemas", "0.2.2", inclusive=False):
-            assert_model_roundtrip(mdl, tmpdir)
+            helpers.assert_model_roundtrip(mdl, tmpdir)
         else:
             with pytest.raises(
                 RuntimeError,
                 match=r"asdf-transform-schemas > 0.2.2 in order to serialize a bounding_box with ignored",
             ):
-                assert_model_roundtrip(mdl, tmpdir)
+                helpers.assert_model_roundtrip(mdl, tmpdir)
     else:
         bbox = ModelBoundingBox({"x": (1, 2)}, mdl, ignored=["y"])
         mdl._user_bounding_box = bbox
@@ -869,13 +861,13 @@ def test_serialize_bbox(tmpdir):
                 RuntimeError,
                 match=r"Bounding box ignored arguments are only supported by astropy 5.1+",
             ):
-                assert_model_roundtrip(mdl, tmpdir)
+                helpers.assert_model_roundtrip(mdl, tmpdir)
         else:
             with pytest.raises(
                 RuntimeError,
                 match=r"asdf-transform-schemas > 0.2.2 in order to serialize a bounding_box with ignored",
             ):
-                assert_model_roundtrip(mdl, tmpdir)
+                helpers.assert_model_roundtrip(mdl, tmpdir)
 
 
 def test_serialize_cbbox(tmpdir):
@@ -889,10 +881,10 @@ def test_serialize_cbbox(tmpdir):
     mdl.bounding_box = bounding_box
 
     if minversion("asdf_transform_schemas", "0.2.2", inclusive=False):
-        assert_model_roundtrip(mdl, tmpdir)
+        helpers.assert_model_roundtrip(mdl, tmpdir)
     else:
         with pytest.raises(
             RuntimeError,
             match=r"asdf-transform-schemas > 0.2.2 in order to serialize a compound bounding_box",
         ):
-            assert_model_roundtrip(mdl, tmpdir)
+            helpers.assert_model_roundtrip(mdl, tmpdir)

--- a/asdf_astropy/converters/transform/tests/test_transform.py
+++ b/asdf_astropy/converters/transform/tests/test_transform.py
@@ -17,24 +17,24 @@ from asdf_astropy import integration
 from asdf_astropy.testing import helpers
 
 
-def assert_bounding_box_roundtrip(bounding_box, tmpdir, version=None):
+def assert_bounding_box_roundtrip(bounding_box, tmp_path, version=None):
     message = (
         "asdf_astropy.converters.transforms.tests.test_transform.assert_bounding_box_round_trip is deprecated."
         "Use asdf_astropy.testing.helpers.assert_bounding_box_roundtrip instead."
     )
     warnings.warn(message, DeprecationWarning)
 
-    return helpers.assert_bounding_box_roundtrip(bounding_box, tmpdir, version=version)
+    return helpers.assert_bounding_box_roundtrip(bounding_box, tmp_path, version=version)
 
 
-def assert_model_roundtrip(model, tmpdir, version=None):
+def assert_model_roundtrip(model, tmp_path, version=None):
     message = (
         "asdf_astropy.converters.transforms.tests.test_transform.assert_model_round_trip is deprecated."
         "Use asdf_astropy.testing.helpers.assert_model_roundtrip instead."
     )
     warnings.warn(message, DeprecationWarning)
 
-    return helpers.assert_bounding_box_roundtrip(model, tmpdir, version=version)
+    return helpers.assert_bounding_box_roundtrip(model, tmp_path, version=version)
 
 
 def create_bounding_boxes():
@@ -88,8 +88,8 @@ def create_bounding_boxes():
     not minversion("asdf_transform_schemas", "0.2.2", inclusive=False),
     reason="Schema not present until versions after asdf-transform-schemas 0.2.2",
 )
-def test_round_trip_bounding_box(bbox, tmpdir):
-    helpers.assert_bounding_box_roundtrip(bbox, tmpdir)
+def test_round_trip_bounding_box(bbox, tmp_path):
+    helpers.assert_bounding_box_roundtrip(bbox, tmp_path)
 
 
 def create_single_models():  # noqa: PLR0915
@@ -471,8 +471,8 @@ if minversion("astropy", "5.1") and not minversion("asdf_transform_schemas", "0.
 
 
 @pytest.mark.parametrize("model", create_single_models())
-def test_single_model(tmpdir, model):
-    helpers.assert_model_roundtrip(model, tmpdir)
+def test_single_model(tmp_path, model):
+    helpers.assert_model_roundtrip(model, tmp_path)
 
 
 def get_all_models():
@@ -508,16 +508,16 @@ def test_all_models_supported(model):
     assert extension_manager.handles_type(model), message
 
 
-def test_legacy_const(tmpdir):
+def test_legacy_const(tmp_path):
     with asdf.config_context() as config:
         config.remove_extension("asdf://asdf-format.org/transform/extensions/transform-1.5.0")
 
         model = astropy_models.Const1D(amplitude=5.0)
-        helpers.assert_model_roundtrip(model, tmpdir, version="1.3.0")
+        helpers.assert_model_roundtrip(model, tmp_path, version="1.3.0")
 
         model = astropy_models.Const2D(amplitude=5.0)
         with pytest.raises(TypeError, match=r".* does not support models with > 1 dimension"):
-            helpers.assert_model_roundtrip(model, tmpdir, version="1.3.0")
+            helpers.assert_model_roundtrip(model, tmp_path, version="1.3.0")
 
 
 COMPOUND_OPERATORS = [
@@ -532,40 +532,40 @@ COMPOUND_OPERATORS = [
 
 
 @pytest.mark.parametrize("operator", COMPOUND_OPERATORS)
-def test_compound_model(tmpdir, operator):
+def test_compound_model(tmp_path, operator):
     left_model = astropy_models.Shift(5)
     right_model = astropy_models.Shift(-1)
     model = getattr(left_model, operator)(right_model)
-    result = helpers.assert_model_roundtrip(model, tmpdir)
+    result = helpers.assert_model_roundtrip(model, tmp_path)
     helpers.assert_model_equal(result.left, left_model)
     helpers.assert_model_equal(result.right, right_model)
     assert result.op == model.op
 
 
-def test_fix_inputs(tmpdir):
+def test_fix_inputs(tmp_path):
     model = astropy_models.Gaussian2D(1, 2, 3, 4, 5)
     fixed_model = astropy_models.fix_inputs(model, {"x": 2.5})
-    result = helpers.assert_model_roundtrip(fixed_model, tmpdir)
+    result = helpers.assert_model_roundtrip(fixed_model, tmp_path)
     helpers.assert_model_equal(result.left, model)
     assert result.right == fixed_model.right
     assert result.op == fixed_model.op
 
 
-def test_units_mapping(tmpdir):
+def test_units_mapping(tmp_path):
     # Basic mapping between units:
     model = astropy_models.UnitsMapping(((u.m, u.dimensionless_unscaled),))
     model.name = "foo"
-    result = helpers.assert_model_roundtrip(model, tmpdir)
+    result = helpers.assert_model_roundtrip(model, tmp_path)
     assert result.mapping == model.mapping
 
     # Remove units:
     model = astropy_models.UnitsMapping(((u.m, None),))
-    result = helpers.assert_model_roundtrip(model, tmpdir)
+    result = helpers.assert_model_roundtrip(model, tmp_path)
     assert result.mapping == model.mapping
 
     # Change a model to accept any units:
     model = astropy_models.UnitsMapping(((None, u.m),))
-    result = helpers.assert_model_roundtrip(model, tmpdir)
+    result = helpers.assert_model_roundtrip(model, tmp_path)
     assert result.mapping == model.mapping
 
     # With equivalencies:
@@ -573,7 +573,7 @@ def test_units_mapping(tmpdir):
         ((u.m, u.dimensionless_unscaled),),
         input_units_equivalencies={"x": u.equivalencies.spectral()},
     )
-    result = helpers.assert_model_roundtrip(model, tmpdir)
+    result = helpers.assert_model_roundtrip(model, tmp_path)
     assert result.mapping == model.mapping
 
     # Allow dimensionless on all inputs:
@@ -581,7 +581,7 @@ def test_units_mapping(tmpdir):
         ((u.m, u.dimensionless_unscaled), (u.s, u.Hz)),
         input_units_allow_dimensionless=True,
     )
-    result = helpers.assert_model_roundtrip(model, tmpdir)
+    result = helpers.assert_model_roundtrip(model, tmp_path)
     assert result.mapping == model.mapping
 
     # Allow dimensionless selectively:
@@ -589,7 +589,7 @@ def test_units_mapping(tmpdir):
         ((u.m, u.dimensionless_unscaled), (u.s, u.Hz)),
         input_units_allow_dimensionless={"x0": True, "x1": False},
     )
-    result = helpers.assert_model_roundtrip(model, tmpdir)
+    result = helpers.assert_model_roundtrip(model, tmp_path)
     assert result.mapping == model.mapping
 
 
@@ -603,8 +603,8 @@ def test_units_mapping(tmpdir):
         astropy_models.Chebyshev1D(2, c0=2, c1=3, c2=0.5, domain=[-2, 2], window=[-0.5, 0.5]),
     ],
 )
-def test_1d_polynomial_with_asdf_standard_version(tmpdir, standard_version, model):
-    result = helpers.assert_model_roundtrip(model, tmpdir, version=standard_version)
+def test_1d_polynomial_with_asdf_standard_version(tmp_path, standard_version, model):
+    result = helpers.assert_model_roundtrip(model, tmp_path, version=standard_version)
     assert result.domain == model.domain
     assert result.window == model.window
 
@@ -638,15 +638,15 @@ def test_1d_polynomial_with_asdf_standard_version(tmpdir, standard_version, mode
         ),
     ],
 )
-def test_2d_polynomial_with_asdf_standard_version(tmpdir, standard_version, model):
-    result = helpers.assert_model_roundtrip(model, tmpdir, version=standard_version)
+def test_2d_polynomial_with_asdf_standard_version(tmp_path, standard_version, model):
+    result = helpers.assert_model_roundtrip(model, tmp_path, version=standard_version)
     assert result.x_domain == model.x_domain
     assert result.y_domain == model.y_domain
     assert result.x_window == model.x_window
     assert result.y_window == model.y_window
 
 
-def test_deserialize_compound_user_inverse(tmpdir):
+def test_deserialize_compound_user_inverse(tmp_path):
     """
     Confirm that we are able to correctly reconstruct a
     compound model with a user inverse set on one of its
@@ -837,7 +837,7 @@ model: !transform/concatenate-1.2.0
                 asdf.open(buff)
 
 
-def test_serialize_bbox(tmpdir):
+def test_serialize_bbox(tmp_path):
     mdl = astropy_models.Const2D(3)
 
     if minversion("astropy", "5.1"):
@@ -845,13 +845,13 @@ def test_serialize_bbox(tmpdir):
 
         bind_bounding_box(mdl, (1, 2), ignored="y")
         if minversion("asdf_transform_schemas", "0.2.2", inclusive=False):
-            helpers.assert_model_roundtrip(mdl, tmpdir)
+            helpers.assert_model_roundtrip(mdl, tmp_path)
         else:
             with pytest.raises(
                 RuntimeError,
                 match=r"asdf-transform-schemas > 0.2.2 in order to serialize a bounding_box with ignored",
             ):
-                helpers.assert_model_roundtrip(mdl, tmpdir)
+                helpers.assert_model_roundtrip(mdl, tmp_path)
     else:
         bbox = ModelBoundingBox({"x": (1, 2)}, mdl, ignored=["y"])
         mdl._user_bounding_box = bbox
@@ -861,16 +861,16 @@ def test_serialize_bbox(tmpdir):
                 RuntimeError,
                 match=r"Bounding box ignored arguments are only supported by astropy 5.1+",
             ):
-                helpers.assert_model_roundtrip(mdl, tmpdir)
+                helpers.assert_model_roundtrip(mdl, tmp_path)
         else:
             with pytest.raises(
                 RuntimeError,
                 match=r"asdf-transform-schemas > 0.2.2 in order to serialize a bounding_box with ignored",
             ):
-                helpers.assert_model_roundtrip(mdl, tmpdir)
+                helpers.assert_model_roundtrip(mdl, tmp_path)
 
 
-def test_serialize_cbbox(tmpdir):
+def test_serialize_cbbox(tmp_path):
     mdl = astropy_models.Shift(1) & astropy_models.Scale(2) & astropy_models.Identity(1)
     mdl.inputs = ("x", "y", "slit_id")
     bounding_boxes = {
@@ -881,10 +881,10 @@ def test_serialize_cbbox(tmpdir):
     mdl.bounding_box = bounding_box
 
     if minversion("asdf_transform_schemas", "0.2.2", inclusive=False):
-        helpers.assert_model_roundtrip(mdl, tmpdir)
+        helpers.assert_model_roundtrip(mdl, tmp_path)
     else:
         with pytest.raises(
             RuntimeError,
             match=r"asdf-transform-schemas > 0.2.2 in order to serialize a compound bounding_box",
         ):
-            helpers.assert_model_roundtrip(mdl, tmpdir)
+            helpers.assert_model_roundtrip(mdl, tmp_path)

--- a/asdf_astropy/io/tests/test_io.py
+++ b/asdf_astropy/io/tests/test_io.py
@@ -14,33 +14,33 @@ def make_table():
     return Table([a, b, c], names=("a", "b", "c"), meta={"name": "first table"})
 
 
-def test_table_io(tmpdir):
-    tmpfile = str(tmpdir.join("table.asdf"))
+def test_table_io(tmp_path):
+    tmp_file = tmp_path / "table.asdf"
 
     table = make_table()
 
-    table.write(tmpfile)
+    table.write(tmp_file)
 
     # Simple sanity check using ASDF directly
-    with asdf.open(tmpfile) as af:
+    with asdf.open(tmp_file) as af:
         assert "data" in af
         assert isinstance(af["data"], Table)
         assert all(af["data"] == table)
 
     # Now test using the table reader
-    new_t = Table.read(tmpfile)
+    new_t = Table.read(tmp_file)
     assert all(new_t == table)
 
 
-def test_table_io_custom_key(tmpdir):
-    tmpfile = str(tmpdir.join("table.asdf"))
+def test_table_io_custom_key(tmp_path):
+    tmp_file = tmp_path / "table.asdf"
 
     table = make_table()
 
-    table.write(tmpfile, data_key="something")
+    table.write(tmp_file, data_key="something")
 
     # Simple sanity check using ASDF directly
-    with asdf.open(tmpfile) as af:
+    with asdf.open(tmp_file) as af:
         assert "something" in af
         assert "data" not in af.keys()
         assert isinstance(af["something"], Table)
@@ -48,24 +48,24 @@ def test_table_io_custom_key(tmpdir):
 
     # Now test using the table reader
     with pytest.raises(KeyError):
-        new_t = Table.read(tmpfile)
+        new_t = Table.read(tmp_file)
 
-    new_t = Table.read(tmpfile, data_key="something")
+    new_t = Table.read(tmp_file, data_key="something")
     assert all(new_t == table)
 
 
-def test_table_io_custom_tree(tmpdir):
-    tmpfile = str(tmpdir.join("table.asdf"))
+def test_table_io_custom_tree(tmp_path):
+    tmp_file = tmp_path / "table.asdf"
 
     table = make_table()
 
     def make_custom_tree(tab):
         return {"foo": {"bar": tab}}
 
-    table.write(tmpfile, make_tree=make_custom_tree)
+    table.write(tmp_file, make_tree=make_custom_tree)
 
     # Simple sanity check using ASDF directly
-    with asdf.open(tmpfile) as af:
+    with asdf.open(tmp_file) as af:
         assert "foo" in af
         assert "bar" in af["foo"]
         assert "data" not in af.keys()
@@ -73,12 +73,12 @@ def test_table_io_custom_tree(tmpdir):
 
     # Now test using table reader
     with pytest.raises(KeyError):
-        new_t = Table.read(tmpfile)
+        new_t = Table.read(tmp_file)
 
     def find_table(asdffile):
         return asdffile["foo"]["bar"]
 
-    new_t = Table.read(tmpfile, find_table=find_table)
+    new_t = Table.read(tmp_file, find_table=find_table)
     assert all(new_t == table)
 
 

--- a/asdf_astropy/testing/helpers.py
+++ b/asdf_astropy/testing/helpers.py
@@ -1,7 +1,7 @@
 """
 Helpers for testing astropy objects in ASDF files.
 """
-from numpy import testing
+import numpy as np
 
 
 def assert_earth_location_equal(a, b):
@@ -88,18 +88,18 @@ def assert_time_equal(a, b):
         assert a.location == b.location
 
     if a.format == "plot_date":
-        testing.assert_array_almost_equal(a.value, b.value)
+        np.testing.assert_array_almost_equal(a.value, b.value)
     else:
-        testing.assert_array_equal(a, b)
+        np.testing.assert_array_equal(a, b)
 
 
 def assert_time_delta_equal(a, b):
     """
     Assert time delta objects are equal
     """
-    testing.assert_array_equal(a.jd, b.jd)
-    testing.assert_array_equal(a.jd2, b.jd2)
-    testing.assert_array_equal(a.sec, b.sec)
+    np.testing.assert_array_equal(a.jd, b.jd)
+    np.testing.assert_array_equal(a.jd2, b.jd2)
+    np.testing.assert_array_equal(a.sec, b.sec)
 
 
 def assert_hdu_list_equal(a, b):
@@ -108,7 +108,7 @@ def assert_hdu_list_equal(a, b):
     """
     assert len(a) == len(b)
     for hdu_a, hdu_b in zip(a, b):
-        testing.assert_array_equal(hdu_a.data, hdu_b.data)
+        np.testing.assert_array_equal(hdu_a.data, hdu_b.data)
         assert len(hdu_a.header.cards) == len(hdu_b.header.cards)
         for card_a, card_b in zip(hdu_a.header.cards, hdu_b.header.cards):
             assert tuple(card_a) == tuple(card_b)
@@ -135,7 +135,7 @@ def assert_table_equal(a, b):
 
     assert len(a) == len(b)
     for row_a, row_b in zip(a, b):
-        testing.assert_array_equal(row_a, row_b)
+        np.testing.assert_array_equal(row_a, row_b)
 
     assert a.colnames == b.colnames
     for column_name in a.colnames:
@@ -145,8 +145,8 @@ def assert_table_equal(a, b):
             assert_description_equal(col_a.description, col_b.description)
             assert col_a.unit == col_b.unit
             assert col_a.meta == col_b.meta
-            testing.assert_array_equal(col_a.data, col_b.data)
-            testing.assert_array_equal(
+            np.testing.assert_array_equal(col_a.data, col_b.data)
+            np.testing.assert_array_equal(
                 getattr(col_a, "mask", [False] * len(col_a)),
                 getattr(col_b, "mask", [False] * len(col_b)),
             )
@@ -185,7 +185,7 @@ def assert_model_equal(a, b):
     assert a.input_units_allow_dimensionless == b.input_units_allow_dimensionless
     assert a.input_units_equivalencies == b.input_units_equivalencies
 
-    testing.assert_array_equal(a.parameters, b.parameters)
+    np.testing.assert_array_equal(a.parameters, b.parameters)
 
     assert a._user_bounding_box == b._user_bounding_box
     try:

--- a/asdf_astropy/testing/helpers.py
+++ b/asdf_astropy/testing/helpers.py
@@ -1,13 +1,22 @@
-from numpy.testing import assert_array_almost_equal, assert_array_equal
+"""
+Helpers for testing astropy objects in ASDF files.
+"""
+from numpy import testing
 
 
 def assert_earth_location_equal(a, b):
+    """
+    Assert earth location objects are equal.
+    """
     __tracebackhide__ = True
 
     assert (a == b).all()
 
 
 def assert_representation_equal(a, b):
+    """
+    Assert representation objects are equal.
+    """
     from astropy import units
 
     __tracebackhide__ = True
@@ -19,6 +28,9 @@ def assert_representation_equal(a, b):
 
 
 def assert_sky_coord_equal(a, b):
+    """
+    Assert sky coordinate objects are equal.
+    """
     __tracebackhide__ = True
 
     assert a.is_equivalent_frame(b)
@@ -29,6 +41,9 @@ def assert_sky_coord_equal(a, b):
 
 
 def assert_frame_equal(a, b):
+    """
+    Assert frame objects are equal.
+    """
     __tracebackhide__ = True
 
     assert type(a) is type(b)
@@ -44,6 +59,9 @@ def assert_frame_equal(a, b):
 
 
 def assert_spectral_coord_equal(a, b):
+    """
+    Assert spectral coordinate objects are equal.
+    """
     from astropy.tests.helper import assert_quantity_allclose
 
     __tracebackhide__ = True
@@ -55,6 +73,9 @@ def assert_spectral_coord_equal(a, b):
 
 
 def assert_time_equal(a, b):
+    """
+    Assert time objects are equal
+    """
     from astropy.coordinates import EarthLocation
 
     assert a.format == b.format
@@ -67,64 +88,36 @@ def assert_time_equal(a, b):
         assert a.location == b.location
 
     if a.format == "plot_date":
-        assert_array_almost_equal(a.value, b.value)
+        testing.assert_array_almost_equal(a.value, b.value)
     else:
-        assert_array_equal(a, b)
+        testing.assert_array_equal(a, b)
 
 
 def assert_time_delta_equal(a, b):
-    assert_array_equal(a.jd, b.jd)
-    assert_array_equal(a.jd2, b.jd2)
-    assert_array_equal(a.sec, b.sec)
+    """
+    Assert time delta objects are equal
+    """
+    testing.assert_array_equal(a.jd, b.jd)
+    testing.assert_array_equal(a.jd2, b.jd2)
+    testing.assert_array_equal(a.sec, b.sec)
 
 
 def assert_hdu_list_equal(a, b):
+    """
+    Assert fits hdulists are equal.
+    """
     assert len(a) == len(b)
     for hdu_a, hdu_b in zip(a, b):
-        assert_array_equal(hdu_a.data, hdu_b.data)
+        testing.assert_array_equal(hdu_a.data, hdu_b.data)
         assert len(hdu_a.header.cards) == len(hdu_b.header.cards)
         for card_a, card_b in zip(hdu_a.header.cards, hdu_b.header.cards):
             assert tuple(card_a) == tuple(card_b)
 
 
-def assert_model_equal(a, b):
-    """
-    Assert that two model instances are equivalent.
-    """
-    if a is None and b is None:
-        return
-
-    assert a.__class__ == b.__class__
-
-    assert a.name == b.name
-    assert a.inputs == b.inputs
-    assert a.input_units == b.input_units
-    assert a.outputs == b.outputs
-    assert a.input_units_allow_dimensionless == b.input_units_allow_dimensionless
-    assert a.input_units_equivalencies == b.input_units_equivalencies
-
-    assert_array_equal(a.parameters, b.parameters)
-
-    assert a._user_bounding_box == b._user_bounding_box
-    try:
-        a_bounding_box = a.bounding_box
-    except NotImplementedError:
-        a_bounding_box = None
-
-    try:
-        b_bounding_box = b.bounding_box
-    except NotImplementedError:
-        b_bounding_box = None
-
-    assert a_bounding_box == b_bounding_box
-
-    assert a.fixed == b.fixed
-    assert a.bounds == b.bounds
-
-    assert_model_equal(a._user_inverse, b._user_inverse)
-
-
 def assert_description_equal(a, b):
+    """
+    Assert table descriptions are equal.
+    """
     if a in ("", None) and b in ("", None):
         return
 
@@ -132,6 +125,9 @@ def assert_description_equal(a, b):
 
 
 def assert_table_equal(a, b):
+    """
+    Assert astropy tables are equal.
+    """
     from astropy.table import Column, MaskedColumn
 
     assert type(a) == type(b)
@@ -139,7 +135,7 @@ def assert_table_equal(a, b):
 
     assert len(a) == len(b)
     for row_a, row_b in zip(a, b):
-        assert_array_equal(row_a, row_b)
+        testing.assert_array_equal(row_a, row_b)
 
     assert a.colnames == b.colnames
     for column_name in a.colnames:
@@ -149,8 +145,8 @@ def assert_table_equal(a, b):
             assert_description_equal(col_a.description, col_b.description)
             assert col_a.unit == col_b.unit
             assert col_a.meta == col_b.meta
-            assert_array_equal(col_a.data, col_b.data)
-            assert_array_equal(
+            testing.assert_array_equal(col_a.data, col_b.data)
+            testing.assert_array_equal(
                 getattr(col_a, "mask", [False] * len(col_a)),
                 getattr(col_b, "mask", [False] * len(col_b)),
             )
@@ -171,6 +167,43 @@ def assert_table_roundtrip(table, tmp_path):
     with asdf.open(file_path) as af:
         assert_table_equal(table, af["table"])
         return af["table"]
+
+
+def assert_model_equal(a, b):
+    """
+    Assert that two model instances are equivalent.
+    """
+    if a is None and b is None:
+        return
+
+    assert a.__class__ == b.__class__
+
+    assert a.name == b.name
+    assert a.inputs == b.inputs
+    assert a.input_units == b.input_units
+    assert a.outputs == b.outputs
+    assert a.input_units_allow_dimensionless == b.input_units_allow_dimensionless
+    assert a.input_units_equivalencies == b.input_units_equivalencies
+
+    testing.assert_array_equal(a.parameters, b.parameters)
+
+    assert a._user_bounding_box == b._user_bounding_box
+    try:
+        a_bounding_box = a.bounding_box
+    except NotImplementedError:
+        a_bounding_box = None
+
+    try:
+        b_bounding_box = b.bounding_box
+    except NotImplementedError:
+        b_bounding_box = None
+
+    assert a_bounding_box == b_bounding_box
+
+    assert a.fixed == b.fixed
+    assert a.bounds == b.bounds
+
+    assert_model_equal(a._user_inverse, b._user_inverse)
 
 
 def assert_bounding_box_roundtrip(bounding_box, tmp_path, version=None):

--- a/asdf_astropy/testing/helpers.py
+++ b/asdf_astropy/testing/helpers.py
@@ -173,14 +173,14 @@ def assert_table_roundtrip(table, tmp_path):
         return af["table"]
 
 
-def assert_bounding_box_roundtrip(bounding_box, tmpdir, version=None):
+def assert_bounding_box_roundtrip(bounding_box, tmp_path, version=None):
     """
     Assert that a bounding_box can be written to an ASDF file and read back
     in without losing any of its essential properties.
     """
     import asdf
 
-    path = str(tmpdir / "test.asdf")
+    path = str(tmp_path / "test.asdf")
 
     with asdf.AsdfFile({"bounding_box": bounding_box}, version=version) as af:
         af.write_to(path)
@@ -189,14 +189,14 @@ def assert_bounding_box_roundtrip(bounding_box, tmpdir, version=None):
         assert bounding_box == af["bounding_box"](bounding_box._model)
 
 
-def assert_model_roundtrip(model, tmpdir, version=None):
+def assert_model_roundtrip(model, tmp_path, version=None):
     """
     Assert that a model can be written to an ASDF file and read back
     in without losing any of its essential properties.
     """
     import asdf
 
-    path = str(tmpdir / "test.asdf")
+    path = str(tmp_path / "test.asdf")
 
     with asdf.AsdfFile({"model": model}, version=version) as af:
         af.write_to(path)

--- a/asdf_astropy/testing/helpers.py
+++ b/asdf_astropy/testing/helpers.py
@@ -171,3 +171,36 @@ def assert_table_roundtrip(table, tmp_path):
     with asdf.open(file_path) as af:
         assert_table_equal(table, af["table"])
         return af["table"]
+
+
+def assert_bounding_box_roundtrip(bounding_box, tmpdir, version=None):
+    """
+    Assert that a bounding_box can be written to an ASDF file and read back
+    in without losing any of its essential properties.
+    """
+    import asdf
+
+    path = str(tmpdir / "test.asdf")
+
+    with asdf.AsdfFile({"bounding_box": bounding_box}, version=version) as af:
+        af.write_to(path)
+
+    with asdf.open(path) as af:
+        assert bounding_box == af["bounding_box"](bounding_box._model)
+
+
+def assert_model_roundtrip(model, tmpdir, version=None):
+    """
+    Assert that a model can be written to an ASDF file and read back
+    in without losing any of its essential properties.
+    """
+    import asdf
+
+    path = str(tmpdir / "test.asdf")
+
+    with asdf.AsdfFile({"model": model}, version=version) as af:
+        af.write_to(path)
+
+    with asdf.open(path) as af:
+        assert_model_equal(model, af["model"])
+        return af["model"]

--- a/docs/asdf-astropy/api.rst
+++ b/docs/asdf-astropy/api.rst
@@ -6,6 +6,8 @@ API
 
 The classes and functions here describe the API for asdf-astropy.
 
+.. automodapi:: asdf_astropy.testing.helpers
+
 .. automodapi:: asdf_astropy.converters
     :inherited-members:
 


### PR DESCRIPTION
Moves all the `assert` testing functions to `asdf_astropy.testing.helpers` and document that module.

Fixes #162