### PR TITLE
Drop Python 3.8 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,6 @@ jobs:
       envs: |
         - linux: py39-parallel-cov
         - linux: py39-test-devdeps-parallel-cov
-        - linux: py38-test-parallel-cov
         - linux: py39-astropylts-parallel-cov
         - linux: py39-transformlts-parallel-cov
       coverage: codecov
@@ -86,7 +85,6 @@ jobs:
       # Any env name which does not start with `pyXY` will use this Python version.
       default_python: '3.9'
       envs: |
-        - linux: py38-test-devdeps-parallel
         - linux: py310-test-devdeps-parallel
         - linux: py311-test-devdeps-parallel
 
@@ -101,7 +99,6 @@ jobs:
       # Any env name which does not start with `pyXY` will use this Python version.
       default_python: '3.9'
       envs: |
-        - linux: py38-test-oldestdeps-parallel-cov
         - linux: py39-test-oldestdep-parallels-cov
       coverage: codecov
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+0.5.0 (unreleased)
+------------------
+
+- Drop support for Python 3.8 in accordance with NEP 29. [#180]
+
 0.4.0 (2023-03-20)
 ------------------
 

--- a/asdf_astropy/integration.py
+++ b/asdf_astropy/integration.py
@@ -1,11 +1,6 @@
-import sys
+import importlib.resources as importlib_resources
 
 from asdf.resource import DirectoryResourceMapping
-
-if sys.version_info < (3, 9):
-    import importlib_resources
-else:
-    import importlib.resources as importlib_resources
 
 
 def get_resource_mappings():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,10 @@ description = "ASDF serialization support for astropy"
 readme = 'README.rst'
 license = { file = 'LICENSE.rst' }
 authors = [{ name = 'The Astropy Developers', email = 'astropy.team@gmail.com' }]
-requires-python = '>=3.8'
+requires-python = '>=3.9'
 classifiers = [
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Development Status :: 5 - Production/Stable',
@@ -21,7 +20,6 @@ dependencies = [
   "asdf-coordinates-schemas>=0.1",
   "asdf-transform-schemas>=0.2.2",
   "astropy>=5.0.4",
-  'importlib_resources>=3; python_version < "3.9"',
   "numpy>=1.20",
   "packaging>=19",
 ]


### PR DESCRIPTION
Astropy has dropped python 3.8, asdf-astropy needs to follow suite.