### PR TITLE
Update `RepresentationConverter` for new class paths in astropy dev

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 ------------------
 
 - Drop support for Python 3.8 in accordance with NEP 29. [#180]
+- Update ``RepresentationConverter`` for new class paths in astropy [#181]
 
 0.4.0 (2023-03-20)
 ------------------

--- a/asdf_astropy/converters/coordinates/representation.py
+++ b/asdf_astropy/converters/coordinates/representation.py
@@ -19,6 +19,21 @@ class RepresentationConverter(Converter):
         "astropy.coordinates.representation.UnitSphericalCosLatDifferential",
         "astropy.coordinates.representation.UnitSphericalDifferential",
         "astropy.coordinates.representation.UnitSphericalRepresentation",
+        # classes were moved in https://github.com/astropy/astropy/pull/14792
+        "astropy.coordinates.representation.cartesian.CartesianDifferential",
+        "astropy.coordinates.representation.cartesian.CartesianRepresentation",
+        "astropy.coordinates.representation.cylindrical.CylindricalDifferential",
+        "astropy.coordinates.representation.cylindrical.CylindricalRepresentation",
+        "astropy.coordinates.representation.spherical.PhysicsSphericalDifferential",
+        "astropy.coordinates.representation.spherical.PhysicsSphericalRepresentation",
+        "astropy.coordinates.representation.spherical.RadialDifferential",
+        "astropy.coordinates.representation.spherical.RadialRepresentation",
+        "astropy.coordinates.representation.spherical.SphericalCosLatDifferential",
+        "astropy.coordinates.representation.spherical.SphericalDifferential",
+        "astropy.coordinates.representation.spherical.SphericalRepresentation",
+        "astropy.coordinates.representation.spherical.UnitSphericalRepresentation",
+        "astropy.coordinates.representation.spherical.UnitSphericalDifferential",
+        "astropy.coordinates.representation.spherical.UnitSphericalCosLatDifferential",
     ]
 
     def to_yaml_tree(self, obj, tag, ctx):


### PR DESCRIPTION
Astropy recently moved a few classes:

https://github.com/astropy/astropy/pull/14792
moved several classes previously in `astropy.coordinates.representation` to submodules. This broke the `RepresentationConverter`. This PR adds the new class paths (and retains the old ones for backwards compatibility).


~https://github.com/astropy/astropy/pull/14763
moved several `Geodetic` classes into `astropy.coordinates.representation`. The `__all__` of this module is used within the asdf-astropy tests to collect classes to test the `RepresentationConverter`. It does not appear that these `Geodetic` classes are currently supported by asdf-astropy so the test was updated to ignore these classes from the list of classes to test.~