### PR TITLE
remove duplicate units in unit converter tests

### DIFF
--- a/asdf_astropy/converters/unit/tests/test_unit.py
+++ b/asdf_astropy/converters/unit/tests/test_unit.py
@@ -18,11 +18,11 @@ def vounit_compatible(unit):
 
 
 def create_vounits():
-    return [u for u in list(units.__dict__.values()) if isinstance(u, units.UnitBase) and vounit_compatible(u)]
+    return {u for u in list(units.__dict__.values()) if isinstance(u, units.UnitBase) and vounit_compatible(u)}
 
 
 def create_non_vounits():
-    return [u for u in list(units.__dict__.values()) if isinstance(u, units.UnitBase) and not vounit_compatible(u)]
+    return {u for u in list(units.__dict__.values()) if isinstance(u, units.UnitBase) and not vounit_compatible(u)}
 
 
 @pytest.mark.parametrize("unit", create_vounits())


### PR DESCRIPTION
The `create_vounits` and `create_non_vounits` generate many duplicate results resulting in many duplicate tests

Here's a few results from `create_vounits`:
```
Unit("fvox"), Unit("fvox"), Unit("fvox"), Unit("avox"), Unit("avox"), Unit("avox"), Unit("zvox"), Unit("zvox"), Unit("zvox")
```

This PR uses a `set` instead of a `list` to remove the duplicates. Prior to this PR `create_vounits` generated 3858 items, removing duplicates with this PR it now generates 1601.