### PR TITLE
TST: Update URL for Scientific Python nightlies

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ description =
     astropylts: with astropy LTS
 
 setenv =
-    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scipy-wheels-nightly/simple
+    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 
 # The following provides some specific pinnings for key packages
 deps =
@@ -47,7 +47,7 @@ extras =
     test
     alldeps: all
 commands_pre=
-    devdeps: pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
+    devdeps: pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
 
     # Generate `requiremments-min.txt`
     oldestdeps: minimum_dependencies asdf-astropy --filename {envtmpdir}/requirements-min.txt


### PR DESCRIPTION
Scientific Python packages have moved their nightly wheels to a new location. xref astropy/astropy#14869

This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.