### PR TITLE
Make class variables immutable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 - Drop support for Python 3.8 in accordance with NEP 29. [#180]
 - Update ``RepresentationConverter`` for new class paths in astropy [#181]
 
+- Fix mutable class variables being used by converters. [#187]
+
 0.4.0 (2023-03-20)
 ------------------
 

--- a/asdf_astropy/converters/coordinates/angle.py
+++ b/asdf_astropy/converters/coordinates/angle.py
@@ -2,9 +2,13 @@ from asdf_astropy.converters.unit.quantity import QuantityConverter
 
 
 class AngleConverter(QuantityConverter):
-    tags = ["tag:astropy.org:astropy/coordinates/angle-*"]
+    @property
+    def tags(self):
+        return ["tag:astropy.org:astropy/coordinates/angle-*"]
 
-    types = ["astropy.coordinates.angles.Angle"]
+    @property
+    def types(self):
+        return ["astropy.coordinates.angles.Angle"]
 
     def from_yaml_tree(self, node, tag, ctx):
         from astropy.coordinates.angles import Angle
@@ -13,9 +17,13 @@ class AngleConverter(QuantityConverter):
 
 
 class LatitudeConverter(QuantityConverter):
-    tags = ["tag:astropy.org:astropy/coordinates/latitude-*"]
+    @property
+    def tags(self):
+        return ["tag:astropy.org:astropy/coordinates/latitude-*"]
 
-    types = ["astropy.coordinates.angles.Latitude"]
+    @property
+    def types(self):
+        return ["astropy.coordinates.angles.Latitude"]
 
     def from_yaml_tree(self, node, tag, ctx):
         from astropy.coordinates.angles import Latitude
@@ -24,9 +32,13 @@ class LatitudeConverter(QuantityConverter):
 
 
 class LongitudeConverter(QuantityConverter):
-    tags = ["tag:astropy.org:astropy/coordinates/longitude-*"]
+    @property
+    def tags(self):
+        return ["tag:astropy.org:astropy/coordinates/longitude-*"]
 
-    types = ["astropy.coordinates.angles.Longitude"]
+    @property
+    def types(self):
+        return ["astropy.coordinates.angles.Longitude"]
 
     def to_yaml_tree(self, obj, tag, ctx):
         tree = super().to_yaml_tree(obj, tag, ctx)

--- a/asdf_astropy/converters/coordinates/earth_location.py
+++ b/asdf_astropy/converters/coordinates/earth_location.py
@@ -2,9 +2,13 @@ from asdf.extension import Converter
 
 
 class EarthLocationConverter(Converter):
-    tags = ["tag:astropy.org:astropy/coordinates/earthlocation-*"]
+    @property
+    def tags(self):
+        return ["tag:astropy.org:astropy/coordinates/earthlocation-*"]
 
-    types = ["astropy.coordinates.earth.EarthLocation"]
+    @property
+    def types(self):
+        return ["astropy.coordinates.earth.EarthLocation"]
 
     def to_yaml_tree(self, obj, tag, ctx):
         return obj.info._represent_as_dict()

--- a/asdf_astropy/converters/coordinates/frame.py
+++ b/asdf_astropy/converters/coordinates/frame.py
@@ -54,11 +54,15 @@ class FrameConverter(Converter):
 
 
 class LegacyICRSConverter(Converter):
-    tags = ["tag:astropy.org:astropy/coordinates/frames/icrs-1.0.0"]
+    @property
+    def tags(self):
+        return ["tag:astropy.org:astropy/coordinates/frames/icrs-*"]
 
     # Leave the types list empty so that the 1.1.0 ICRS converter
     # is used on write.
-    types = []
+    @property
+    def types(self):
+        return []
 
     def to_yaml_tree(self, obj, tag, ctx):
         from astropy.units import Quantity

--- a/asdf_astropy/converters/coordinates/representation.py
+++ b/asdf_astropy/converters/coordinates/representation.py
@@ -2,39 +2,43 @@ from asdf.extension import Converter
 
 
 class RepresentationConverter(Converter):
-    tags = ["tag:astropy.org:astropy/coordinates/representation-*"]
+    @property
+    def tags(self):
+        return ["tag:astropy.org:astropy/coordinates/representation-*"]
 
-    types = [
-        "astropy.coordinates.representation.CartesianDifferential",
-        "astropy.coordinates.representation.CartesianRepresentation",
-        "astropy.coordinates.representation.CylindricalDifferential",
-        "astropy.coordinates.representation.CylindricalRepresentation",
-        "astropy.coordinates.representation.PhysicsSphericalDifferential",
-        "astropy.coordinates.representation.PhysicsSphericalRepresentation",
-        "astropy.coordinates.representation.RadialDifferential",
-        "astropy.coordinates.representation.RadialRepresentation",
-        "astropy.coordinates.representation.SphericalCosLatDifferential",
-        "astropy.coordinates.representation.SphericalDifferential",
-        "astropy.coordinates.representation.SphericalRepresentation",
-        "astropy.coordinates.representation.UnitSphericalCosLatDifferential",
-        "astropy.coordinates.representation.UnitSphericalDifferential",
-        "astropy.coordinates.representation.UnitSphericalRepresentation",
-        # classes were moved in https://github.com/astropy/astropy/pull/14792
-        "astropy.coordinates.representation.cartesian.CartesianDifferential",
-        "astropy.coordinates.representation.cartesian.CartesianRepresentation",
-        "astropy.coordinates.representation.cylindrical.CylindricalDifferential",
-        "astropy.coordinates.representation.cylindrical.CylindricalRepresentation",
-        "astropy.coordinates.representation.spherical.PhysicsSphericalDifferential",
-        "astropy.coordinates.representation.spherical.PhysicsSphericalRepresentation",
-        "astropy.coordinates.representation.spherical.RadialDifferential",
-        "astropy.coordinates.representation.spherical.RadialRepresentation",
-        "astropy.coordinates.representation.spherical.SphericalCosLatDifferential",
-        "astropy.coordinates.representation.spherical.SphericalDifferential",
-        "astropy.coordinates.representation.spherical.SphericalRepresentation",
-        "astropy.coordinates.representation.spherical.UnitSphericalRepresentation",
-        "astropy.coordinates.representation.spherical.UnitSphericalDifferential",
-        "astropy.coordinates.representation.spherical.UnitSphericalCosLatDifferential",
-    ]
+    @property
+    def types(self):
+        return [
+            "astropy.coordinates.representation.CartesianDifferential",
+            "astropy.coordinates.representation.CartesianRepresentation",
+            "astropy.coordinates.representation.CylindricalDifferential",
+            "astropy.coordinates.representation.CylindricalRepresentation",
+            "astropy.coordinates.representation.PhysicsSphericalDifferential",
+            "astropy.coordinates.representation.PhysicsSphericalRepresentation",
+            "astropy.coordinates.representation.RadialDifferential",
+            "astropy.coordinates.representation.RadialRepresentation",
+            "astropy.coordinates.representation.SphericalCosLatDifferential",
+            "astropy.coordinates.representation.SphericalDifferential",
+            "astropy.coordinates.representation.SphericalRepresentation",
+            "astropy.coordinates.representation.UnitSphericalCosLatDifferential",
+            "astropy.coordinates.representation.UnitSphericalDifferential",
+            "astropy.coordinates.representation.UnitSphericalRepresentation",
+            # classes were moved in https://github.com/astropy/astropy/pull/14792
+            "astropy.coordinates.representation.cartesian.CartesianDifferential",
+            "astropy.coordinates.representation.cartesian.CartesianRepresentation",
+            "astropy.coordinates.representation.cylindrical.CylindricalDifferential",
+            "astropy.coordinates.representation.cylindrical.CylindricalRepresentation",
+            "astropy.coordinates.representation.spherical.PhysicsSphericalDifferential",
+            "astropy.coordinates.representation.spherical.PhysicsSphericalRepresentation",
+            "astropy.coordinates.representation.spherical.RadialDifferential",
+            "astropy.coordinates.representation.spherical.RadialRepresentation",
+            "astropy.coordinates.representation.spherical.SphericalCosLatDifferential",
+            "astropy.coordinates.representation.spherical.SphericalDifferential",
+            "astropy.coordinates.representation.spherical.SphericalRepresentation",
+            "astropy.coordinates.representation.spherical.UnitSphericalRepresentation",
+            "astropy.coordinates.representation.spherical.UnitSphericalDifferential",
+            "astropy.coordinates.representation.spherical.UnitSphericalCosLatDifferential",
+        ]
 
     def to_yaml_tree(self, obj, tag, ctx):
         components = {}

--- a/asdf_astropy/converters/coordinates/sky_coord.py
+++ b/asdf_astropy/converters/coordinates/sky_coord.py
@@ -2,9 +2,13 @@ from asdf.extension import Converter
 
 
 class SkyCoordConverter(Converter):
-    tags = ["tag:astropy.org:astropy/coordinates/skycoord-*"]
+    @property
+    def tags(self):
+        return ["tag:astropy.org:astropy/coordinates/skycoord-*"]
 
-    types = ["astropy.coordinates.sky_coordinate.SkyCoord"]
+    @property
+    def types(self):
+        return ["astropy.coordinates.sky_coordinate.SkyCoord"]
 
     def to_yaml_tree(self, obj, tag, ctx):
         return obj.info._represent_as_dict()

--- a/asdf_astropy/converters/coordinates/spectral_coord.py
+++ b/asdf_astropy/converters/coordinates/spectral_coord.py
@@ -3,9 +3,13 @@ from asdf.tags.core.ndarray import NDArrayType
 
 
 class SpectralCoordConverter(Converter):
-    tags = ["tag:astropy.org:astropy/coordinates/spectralcoord-*"]
+    @property
+    def tags(self):
+        return ["tag:astropy.org:astropy/coordinates/spectralcoord-*"]
 
-    types = ["astropy.coordinates.spectral_coordinate.SpectralCoord"]
+    @property
+    def types(self):
+        return ["astropy.coordinates.spectral_coordinate.SpectralCoord"]
 
     def to_yaml_tree(self, obj, tag, ctx):
         node = {

--- a/asdf_astropy/converters/fits/fits.py
+++ b/asdf_astropy/converters/fits/fits.py
@@ -66,10 +66,20 @@ class FitsConverter(Converter):
 
 
 class AsdfFitsConverter(FitsConverter):
-    tags = ["tag:stsci.edu:asdf/fits/fits-*"]
-    types = []
+    @property
+    def tags(self):
+        return ["tag:stsci.edu:asdf/fits/fits-*"]
+
+    @property
+    def types(self):
+        return []
 
 
 class AstropyFitsConverter(FitsConverter):
-    tags = ["tag:astropy.org:astropy/fits/fits-*"]
-    types = ["astropy.io.fits.hdu.hdulist.HDUList"]
+    @property
+    def tags(self):
+        return ["tag:astropy.org:astropy/fits/fits-*"]
+
+    @property
+    def types(self):
+        return ["astropy.io.fits.hdu.hdulist.HDUList"]

--- a/asdf_astropy/converters/table/table.py
+++ b/asdf_astropy/converters/table/table.py
@@ -3,12 +3,16 @@ from asdf.tags.core.ndarray import NDArrayType
 
 
 class ColumnConverter(Converter):
-    tags = ["tag:stsci.edu:asdf/core/column-*"]
+    @property
+    def tags(self):
+        return ["tag:stsci.edu:asdf/core/column-*"]
 
-    types = [
-        "astropy.table.column.Column",
-        "astropy.table.column.MaskedColumn",
-    ]
+    @property
+    def types(self):
+        return [
+            "astropy.table.column.Column",
+            "astropy.table.column.MaskedColumn",
+        ]
 
     def to_yaml_tree(self, obj, tag, ctx):
         node = {"data": obj.data, "name": obj.name}
@@ -46,9 +50,13 @@ class ColumnConverter(Converter):
 
 
 class AsdfTableConverter(Converter):
-    tags = ["tag:stsci.edu:asdf/core/table-*"]
+    @property
+    def tags(self):
+        return ["tag:stsci.edu:asdf/core/table-*"]
 
-    types = []
+    @property
+    def types(self):
+        return []
 
     def to_yaml_tree(self, obj, tag, ctx):
         msg = "astropy does not support writing astropy.table.Table with the ASDF table-1.0.0 tag"
@@ -61,12 +69,16 @@ class AsdfTableConverter(Converter):
 
 
 class AstropyTableConverter(Converter):
-    tags = ["tag:astropy.org:astropy/table/table-*"]
+    @property
+    def tags(self):
+        return ["tag:astropy.org:astropy/table/table-*"]
 
-    types = [
-        "astropy.table.table.Table",
-        "astropy.table.table.QTable",
-    ]
+    @property
+    def types(self):
+        return [
+            "astropy.table.table.Table",
+            "astropy.table.table.QTable",
+        ]
 
     def to_yaml_tree(self, obj, tag, ctx):
         from astropy.table import QTable

--- a/asdf_astropy/converters/time/time.py
+++ b/asdf_astropy/converters/time/time.py
@@ -12,9 +12,13 @@ _ASTROPY_FORMAT_TO_ASDF_FORMAT = {
 
 
 class TimeConverter(Converter):
-    tags = ["tag:stsci.edu:asdf/time/time-*"]
+    @property
+    def tags(self):
+        return ["tag:stsci.edu:asdf/time/time-*"]
 
-    types = ["astropy.time.core.Time"]
+    @property
+    def types(self):
+        return ["astropy.time.core.Time"]
 
     def to_yaml_tree(self, obj, tag, ctx):
         from astropy.time import Time

--- a/asdf_astropy/converters/time/time_delta.py
+++ b/asdf_astropy/converters/time/time_delta.py
@@ -2,9 +2,13 @@ from asdf.extension import Converter
 
 
 class TimeDeltaConverter(Converter):
-    tags = ["tag:astropy.org:astropy/time/timedelta-*"]
+    @property
+    def tags(self):
+        return ["tag:astropy.org:astropy/time/timedelta-*"]
 
-    types = ["astropy.time.core.TimeDelta"]
+    @property
+    def types(self):
+        return ["astropy.time.core.TimeDelta"]
 
     def to_yaml_tree(self, obj, tag, ctx):
         return obj.info._represent_as_dict()

--- a/asdf_astropy/converters/transform/compound.py
+++ b/asdf_astropy/converters/transform/compound.py
@@ -34,18 +34,22 @@ class CompoundConverter(TransformConverterBase):
     ASDF serialization support for CompoundModel.
     """
 
-    tags = [
-        "tag:stsci.edu:asdf/transform/add-*",
-        "tag:stsci.edu:asdf/transform/subtract-*",
-        "tag:stsci.edu:asdf/transform/multiply-*",
-        "tag:stsci.edu:asdf/transform/divide-*",
-        "tag:stsci.edu:asdf/transform/power-*",
-        "tag:stsci.edu:asdf/transform/compose-*",
-        "tag:stsci.edu:asdf/transform/concatenate-*",
-        "tag:stsci.edu:asdf/transform/fix_inputs-*",
-    ]
+    @property
+    def tags(self):
+        return [
+            "tag:stsci.edu:asdf/transform/add-*",
+            "tag:stsci.edu:asdf/transform/subtract-*",
+            "tag:stsci.edu:asdf/transform/multiply-*",
+            "tag:stsci.edu:asdf/transform/divide-*",
+            "tag:stsci.edu:asdf/transform/power-*",
+            "tag:stsci.edu:asdf/transform/compose-*",
+            "tag:stsci.edu:asdf/transform/concatenate-*",
+            "tag:stsci.edu:asdf/transform/fix_inputs-*",
+        ]
 
-    types = ["astropy.modeling.core.CompoundModel"]
+    @property
+    def types(self):
+        return ["astropy.modeling.core.CompoundModel"]
 
     def select_tag(self, model, tags, ctx):
         tag_name = _OPERATOR_TO_TAG_NAME[model.op]

--- a/asdf_astropy/converters/transform/functional_models.py
+++ b/asdf_astropy/converters/transform/functional_models.py
@@ -14,12 +14,16 @@ class ConstantConverter(TransformConverterBase):
     # previously all values were 1D.
     _2D_MIN_VERSION = parse_version("1.4.0")
 
-    tags = ["tag:stsci.edu:asdf/transform/constant-*"]
+    @property
+    def tags(self):
+        return ["tag:stsci.edu:asdf/transform/constant-*"]
 
-    types = [
-        "astropy.modeling.functional_models.Const1D",
-        "astropy.modeling.functional_models.Const2D",
-    ]
+    @property
+    def types(self):
+        return [
+            "astropy.modeling.functional_models.Const1D",
+            "astropy.modeling.functional_models.Const2D",
+        ]
 
     def to_yaml_tree_transform(self, model, tag, ctx):
         from astropy.modeling.functional_models import Const1D, Const2D

--- a/asdf_astropy/converters/transform/mappings.py
+++ b/asdf_astropy/converters/transform/mappings.py
@@ -8,9 +8,13 @@ class IdentityConverter(TransformConverterBase):
     ASDF support for serializing the Identity model.
     """
 
-    tags = ["tag:stsci.edu:asdf/transform/identity-*"]
+    @property
+    def tags(self):
+        return ["tag:stsci.edu:asdf/transform/identity-*"]
 
-    types = ["astropy.modeling.mappings.Identity"]
+    @property
+    def types(self):
+        return ["astropy.modeling.mappings.Identity"]
 
     def to_yaml_tree_transform(self, model, tag, ctx):
         node = {}
@@ -29,9 +33,13 @@ class RemapAxesConverter(TransformConverterBase):
     ASDF support for serializing the Mapping model
     """
 
-    tags = ["tag:stsci.edu:asdf/transform/remap_axes-*"]
+    @property
+    def tags(self):
+        return ["tag:stsci.edu:asdf/transform/remap_axes-*"]
 
-    types = ["astropy.modeling.mappings.Mapping"]
+    @property
+    def types(self):
+        return ["astropy.modeling.mappings.Mapping"]
 
     def to_yaml_tree_transform(self, model, tag, ctx):
         node = {"mapping": list(model.mapping)}
@@ -53,9 +61,13 @@ class UnitsMappingConverter(Converter):
     from other models.
     """
 
-    tags = ["tag:astropy.org:astropy/transform/units_mapping-*"]
+    @property
+    def tags(self):
+        return ["tag:astropy.org:astropy/transform/units_mapping-*"]
 
-    types = ["astropy.modeling.mappings.UnitsMapping"]
+    @property
+    def types(self):
+        return ["astropy.modeling.mappings.UnitsMapping"]
 
     def to_yaml_tree(self, model, tag, ctx):
         node = {}

--- a/asdf_astropy/converters/transform/math_functions.py
+++ b/asdf_astropy/converters/transform/math_functions.py
@@ -48,6 +48,8 @@ _MODEL_NAMES = [
     "True_divideUfunc",
 ]
 
+_MODEL_TYPES = [f"astropy.modeling.math_functions.{m}" for m in _MODEL_NAMES]
+
 
 class MathFunctionsConverter(TransformConverterBase):
     """
@@ -55,9 +57,13 @@ class MathFunctionsConverter(TransformConverterBase):
     each of which corresponds to a numpy ufunc.
     """
 
-    tags = ["tag:stsci.edu:asdf/transform/math_functions-*"]
+    @property
+    def tags(self):
+        return ["tag:stsci.edu:asdf/transform/math_functions-*"]
 
-    types = ["astropy.modeling.math_functions." + m for m in _MODEL_NAMES]
+    @property
+    def types(self):
+        return _MODEL_TYPES
 
     def to_yaml_tree_transform(self, model, tag, ctx):
         return {"func_name": model.func.__name__}

--- a/asdf_astropy/converters/transform/polynomial.py
+++ b/asdf_astropy/converters/transform/polynomial.py
@@ -16,12 +16,16 @@ class PolynomialConverter(TransformConverterBase):
     # versions because they don't validate.
     _DOMAIN_WINDOW_MIN_VERSION = parse_version("1.2.0")
 
-    tags = ["tag:stsci.edu:asdf/transform/polynomial-*"]
+    @property
+    def tags(self):
+        return ["tag:stsci.edu:asdf/transform/polynomial-*"]
 
-    types = [
-        "astropy.modeling.polynomial.Polynomial1D",
-        "astropy.modeling.polynomial.Polynomial2D",
-    ]
+    @property
+    def types(self):
+        return [
+            "astropy.modeling.polynomial.Polynomial1D",
+            "astropy.modeling.polynomial.Polynomial2D",
+        ]
 
     def to_yaml_tree_transform(self, model, tag, ctx):
         from astropy.modeling.polynomial import Polynomial1D, Polynomial2D
@@ -95,6 +99,18 @@ class PolynomialConverter(TransformConverterBase):
         return model
 
 
+_CLASS_NAME_TO_POLY_INFO = {
+    "Legendre1D": ("legendre", 1),
+    "Legendre2D": ("legendre", 2),
+    "Chebyshev1D": ("chebyshev", 1),
+    "Chebyshev2D": ("chebyshev", 2),
+    "Hermite1D": ("hermite", 1),
+    "Hermite2D": ("hermite", 2),
+}
+
+_POLY_INFO_TO_CLASS_NAME = {v: k for k, v in _CLASS_NAME_TO_POLY_INFO.items()}
+
+
 class OrthoPolynomialConverter(TransformConverterBase):
     """
     ASDF support for serializing models that inherit
@@ -102,30 +118,24 @@ class OrthoPolynomialConverter(TransformConverterBase):
     """
 
     # Map of model class name to (polynomial type, number of dimensions) tuple:
-    _CLASS_NAME_TO_POLY_INFO = {
-        "Legendre1D": ("legendre", 1),
-        "Legendre2D": ("legendre", 2),
-        "Chebyshev1D": ("chebyshev", 1),
-        "Chebyshev2D": ("chebyshev", 2),
-        "Hermite1D": ("hermite", 1),
-        "Hermite2D": ("hermite", 2),
-    }
 
-    _POLY_INFO_TO_CLASS_NAME = {v: k for k, v in _CLASS_NAME_TO_POLY_INFO.items()}
+    @property
+    def tags(self):
+        return ["tag:stsci.edu:asdf/transform/ortho_polynomial-*"]
 
-    tags = ["tag:stsci.edu:asdf/transform/ortho_polynomial-*"]
-
-    types = [
-        "astropy.modeling.polynomial.Legendre1D",
-        "astropy.modeling.polynomial.Legendre2D",
-        "astropy.modeling.polynomial.Chebyshev1D",
-        "astropy.modeling.polynomial.Chebyshev2D",
-        "astropy.modeling.polynomial.Hermite1D",
-        "astropy.modeling.polynomial.Hermite2D",
-    ]
+    @property
+    def types(self):
+        return [
+            "astropy.modeling.polynomial.Legendre1D",
+            "astropy.modeling.polynomial.Legendre2D",
+            "astropy.modeling.polynomial.Chebyshev1D",
+            "astropy.modeling.polynomial.Chebyshev2D",
+            "astropy.modeling.polynomial.Hermite1D",
+            "astropy.modeling.polynomial.Hermite2D",
+        ]
 
     def to_yaml_tree_transform(self, model, tag, ctx):
-        poly_type = self._CLASS_NAME_TO_POLY_INFO[model.__class__.__name__][0]
+        poly_type = _CLASS_NAME_TO_POLY_INFO[model.__class__.__name__][0]
         if model.n_inputs == 1:
             coefficients = np.array(model.parameters)
         else:
@@ -157,7 +167,7 @@ class OrthoPolynomialConverter(TransformConverterBase):
         poly_type = node["polynomial_type"]
         n_dim = coefficients.ndim
 
-        class_name = self._POLY_INFO_TO_CLASS_NAME[(poly_type, n_dim)]
+        class_name = _POLY_INFO_TO_CLASS_NAME[(poly_type, n_dim)]
         model_type = getattr(polynomial, class_name)
 
         coefficients = np.asarray(node["coefficients"])

--- a/asdf_astropy/converters/transform/properties.py
+++ b/asdf_astropy/converters/transform/properties.py
@@ -3,8 +3,13 @@ from astropy.utils import minversion
 
 
 class ModelBoundingBoxConverter(Converter):
-    tags = ["tag:stsci.edu:asdf/transform/property/bounding_box-1.0.0"]
-    types = ["astropy.modeling.bounding_box.ModelBoundingBox"]
+    @property
+    def tags(self):
+        return ["tag:stsci.edu:asdf/transform/property/bounding_box-*"]
+
+    @property
+    def types(self):
+        return ["astropy.modeling.bounding_box.ModelBoundingBox"]
 
     def to_yaml_tree(self, bbox, tag, ctx):
         return {
@@ -40,8 +45,13 @@ class ModelBoundingBoxConverter(Converter):
 
 
 class CompoundBoundingBoxConverter(Converter):
-    tags = ["tag:stsci.edu:asdf/transform/property/compound_bounding_box-1.0.0"]
-    types = ["astropy.modeling.bounding_box.CompoundBoundingBox"]
+    @property
+    def tags(self):
+        return ["tag:stsci.edu:asdf/transform/property/compound_bounding_box-1.0.0"]
+
+    @property
+    def types(self):
+        return ["astropy.modeling.bounding_box.CompoundBoundingBox"]
 
     def to_yaml_tree(self, cbbox, tag, ctx):
         node = {

--- a/asdf_astropy/converters/transform/rotations.py
+++ b/asdf_astropy/converters/transform/rotations.py
@@ -7,13 +7,17 @@ class Rotate3DConverter(TransformConverterBase):
     use the rotate3d tag.
     """
 
-    tags = ["tag:stsci.edu:asdf/transform/rotate3d-*"]
+    @property
+    def tags(self):
+        return ["tag:stsci.edu:asdf/transform/rotate3d-*"]
 
-    types = [
-        "astropy.modeling.rotations.RotateNative2Celestial",
-        "astropy.modeling.rotations.RotateCelestial2Native",
-        "astropy.modeling.rotations.EulerAngleRotation",
-    ]
+    @property
+    def types(self):
+        return [
+            "astropy.modeling.rotations.RotateNative2Celestial",
+            "astropy.modeling.rotations.RotateCelestial2Native",
+            "astropy.modeling.rotations.EulerAngleRotation",
+        ]
 
     def to_yaml_tree_transform(self, model, tag, ctx):
         from astropy.modeling import rotations
@@ -59,12 +63,16 @@ class RotationSequenceConverter(TransformConverterBase):
     ASDF support for serializing rotation sequence models.
     """
 
-    tags = ["tag:stsci.edu:asdf/transform/rotate_sequence_3d-*"]
+    @property
+    def tags(self):
+        return ["tag:stsci.edu:asdf/transform/rotate_sequence_3d-*"]
 
-    types = [
-        "astropy.modeling.rotations.RotationSequence3D",
-        "astropy.modeling.rotations.SphericalRotationSequence",
-    ]
+    @property
+    def types(self):
+        return [
+            "astropy.modeling.rotations.RotationSequence3D",
+            "astropy.modeling.rotations.SphericalRotationSequence",
+        ]
 
     def to_yaml_tree_transform(self, model, tag, ctx):
         from astropy.modeling import rotations

--- a/asdf_astropy/converters/transform/spline.py
+++ b/asdf_astropy/converters/transform/spline.py
@@ -6,8 +6,13 @@ class SplineConverter(TransformConverterBase):
     ASDF support for serializing 1D spline models
     """
 
-    tags = ["tag:stsci.edu:asdf/transform/spline1d-*"]
-    types = ["astropy.modeling.spline.Spline1D"]
+    @property
+    def tags(self):
+        return ["tag:stsci.edu:asdf/transform/spline1d-*"]
+
+    @property
+    def types(self):
+        return ["astropy.modeling.spline.Spline1D"]
 
     def to_yaml_tree_transform(self, model, tag, ctx):
         return {"knots": model.t, "coefficients": model.c, "degree": model.degree}

--- a/asdf_astropy/converters/transform/tabular.py
+++ b/asdf_astropy/converters/transform/tabular.py
@@ -8,12 +8,16 @@ class TabularConverter(TransformConverterBase):
     ASDF support for serializing tabular models.
     """
 
-    tags = ["tag:stsci.edu:asdf/transform/tabular-*"]
+    @property
+    def tags(self):
+        return ["tag:stsci.edu:asdf/transform/tabular-*"]
 
-    types = [
-        "astropy.modeling.tabular.Tabular1D",
-        "astropy.modeling.tabular.Tabular2D",
-    ]
+    @property
+    def types(self):
+        return [
+            "astropy.modeling.tabular.Tabular1D",
+            "astropy.modeling.tabular.Tabular2D",
+        ]
 
     def to_yaml_tree_transform(self, model, tag, ctx):
         node = {}

--- a/asdf_astropy/converters/unit/equivalency.py
+++ b/asdf_astropy/converters/unit/equivalency.py
@@ -2,9 +2,13 @@ from asdf.extension import Converter
 
 
 class EquivalencyConverter(Converter):
-    tags = ["tag:astropy.org:astropy/units/equivalency-*"]
+    @property
+    def tags(self):
+        return ["tag:astropy.org:astropy/units/equivalency-*"]
 
-    types = ["astropy.units.equivalencies.Equivalency"]
+    @property
+    def types(self):
+        return ["astropy.units.equivalencies.Equivalency"]
 
     def to_yaml_tree(self, obj, tag, ctx):
         return [

--- a/asdf_astropy/converters/unit/magunit.py
+++ b/asdf_astropy/converters/unit/magunit.py
@@ -2,11 +2,13 @@ from asdf.extension import Converter
 
 
 class MagUnitConverter(Converter):
-    tags = ["tag:astropy.org:astropy/units/magunit-*"]
+    @property
+    def tags(self):
+        return ["tag:astropy.org:astropy/units/magunit-*"]
 
-    types = [
-        "astropy.units.function.logarithmic.MagUnit",
-    ]
+    @property
+    def types(self):
+        return ["astropy.units.function.logarithmic.MagUnit"]
 
     def to_yaml_tree(self, obj, tag, ctx):
         return {"unit": obj.physical_unit}

--- a/asdf_astropy/converters/unit/quantity.py
+++ b/asdf_astropy/converters/unit/quantity.py
@@ -3,14 +3,18 @@ from asdf.tags.core.ndarray import NDArrayType
 
 
 class QuantityConverter(Converter):
-    tags = ["tag:stsci.edu:asdf/unit/quantity-*"]
+    @property
+    def tags(self):
+        return ["tag:stsci.edu:asdf/unit/quantity-*"]
 
-    types = [
-        "astropy.units.quantity.Quantity",
-        # The Distance class has no tag of its own, so we
-        # just serialize it as a quantity.
-        "astropy.coordinates.distances.Distance",
-    ]
+    @property
+    def types(self):
+        return [
+            "astropy.units.quantity.Quantity",
+            # The Distance class has no tag of its own, so we
+            # just serialize it as a quantity.
+            "astropy.coordinates.distances.Distance",
+        ]
 
     def to_yaml_tree(self, obj, tag, ctx):
         node = {

--- a/asdf_astropy/converters/unit/tests/test_magunit.py
+++ b/asdf_astropy/converters/unit/tests/test_magunit.py
@@ -4,7 +4,7 @@ from astropy import units
 
 
 def create_builtin_units():
-    return [u for u in list(units.__dict__.values()) if isinstance(u, units.MagUnit)]
+    return {u for u in list(units.__dict__.values()) if isinstance(u, units.MagUnit)}
 
 
 @pytest.mark.parametrize("unit", create_builtin_units())
@@ -34,7 +34,7 @@ def create_magunits():
             else:
                 magunits.append(magunit)
 
-    return magunits
+    return set(magunits)
 
 
 @pytest.mark.parametrize("unit", create_magunits())

--- a/asdf_astropy/converters/unit/unit.py
+++ b/asdf_astropy/converters/unit/unit.py
@@ -4,22 +4,26 @@ from asdf.extension import Converter
 
 
 class UnitConverter(Converter):
-    tags = [
-        "tag:stsci.edu:asdf/unit/unit-*",
-        "tag:astropy.org:astropy/units/unit-*",
-    ]
+    @property
+    def tags(self):
+        return [
+            "tag:stsci.edu:asdf/unit/unit-*",
+            "tag:astropy.org:astropy/units/unit-*",
+        ]
 
-    types = [
-        "astropy.units.core.CompositeUnit",
-        "astropy.units.core.IrreducibleUnit",
-        "astropy.units.core.NamedUnit",
-        "astropy.units.core.PrefixUnit",
-        "astropy.units.core.Unit",
-        "astropy.units.core.UnitBase",
-        "astropy.units.core.UnrecognizedUnit",
-        "astropy.units.function.mixin.IrreducibleFunctionUnit",
-        "astropy.units.function.mixin.RegularFunctionUnit",
-    ]
+    @property
+    def types(self):
+        return [
+            "astropy.units.core.CompositeUnit",
+            "astropy.units.core.IrreducibleUnit",
+            "astropy.units.core.NamedUnit",
+            "astropy.units.core.PrefixUnit",
+            "astropy.units.core.Unit",
+            "astropy.units.core.UnitBase",
+            "astropy.units.core.UnrecognizedUnit",
+            "astropy.units.function.mixin.IrreducibleFunctionUnit",
+            "astropy.units.function.mixin.RegularFunctionUnit",
+        ]
 
     def select_tag(self, obj, tags, ctx):
         from astropy.units import UnitsError, UnitsWarning


### PR DESCRIPTION
An issue pointed out in #183 is that we have many of the classes which define mutable class variables. In general, mutable class variables should not be used because the state of that variable is shared across all instances. Thus they should be made to be immutable objects.

This PR corrects this issue for this package.

Note that this issue occurs mostly for the  `tags` and `types` attributes of the converters. These were turned into properties instead of tuples because ASDF does not support these values being anything other than lists (ASDF will literally segfault). 