### PR TITLE
Drop oldest supported numpy from build-system

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 - Drop support for Python 3.8 in accordance with NEP 29. [#180]
 - Update ``RepresentationConverter`` for new class paths in astropy [#181]
 - Update Converters so that all Class Variables are immutable [#188]
+- Remove ``oldest-supported-numpy`` from ``pyproject.toml`` ``build-system``
+  as this was never needed and will cause problems building on python 3.12 betas. [#193]
 
 0.4.0 (2023-03-20)
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,10 +51,8 @@ test = [
 [build-system]
 build-backend = 'setuptools.build_meta'
 requires = [
-  "oldest-supported-numpy",
   "setuptools>=60",
   "setuptools_scm[toml]>=3.4",
-  "wheel",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
This is superfluous and was never needed.
It appears to have come from copy/paste from the old astropy package template