### PR TITLE
generate a unique uri for extensions that convert core types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@
 - Update Converters so that all Class Variables are immutable [#188]
 - Remove ``oldest-supported-numpy`` from ``pyproject.toml`` ``build-system``
   as this was never needed and will cause problems building on python 3.12 betas. [#193]
+- Use unique uri for extensions that implement converters for core asdf types [#199]
 
 0.4.0 (2023-03-20)
 ------------------

--- a/asdf_astropy/_manifest.py
+++ b/asdf_astropy/_manifest.py
@@ -1,3 +1,4 @@
+import re
 from itertools import chain
 
 from asdf import extension
@@ -10,10 +11,13 @@ class CompoundManifestExtension(extension.Extension):
 
     def __init__(self, extensions):
         self._extensions = extensions
+        # overwrite extension uri from first extension (the one from asdf-standard)
+        # so that this extension uses a new, unique uri
+        self._extension_uri = re.sub("asdf-format", "astropy", extensions[0].extension_uri)
 
     @property
     def extension_uri(self):
-        return self._extensions[0].extension_uri
+        return self._extension_uri
 
     @property
     def asdf_standard_requirement(self):

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     py38-cov
     py{39,}-test-numpy{119,120,121,122}
     py38-astropylts
+    py39-test-oldestdep-parallels-cov
 requires =
     setuptools >= 30.3.0
     pip >= 19.3.1


### PR DESCRIPTION
asdf-astropy currently implements converters for a number of core asdf types/tags. These converters are registered with an extension that is created in part using the core manifests provided by asdf-standard:
https://github.com/astropy/asdf-astropy/blob/38f76e19b85bf44b7d83d8f76f6705121e1f49ad/asdf_astropy/extensions.py#L520-L539

Because these extensions use the extension uri defined in the core manifests yet do not fully support all tags, this creates an issue where files can be written with incomplete extension history.

For example, using current development version of asdf, writing an empty tree produces the following file:
```yaml
#ASDF 1.0.0
#ASDF_STANDARD 1.5.0
%YAML 1.1
%TAG ! tag:stsci.edu:asdf/
--- !core/asdf-1.1.0
asdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: 'http://github.com/asdf-format/asdf',
  name: asdf, version: 3.0.0.dev591+g3c724f15}
history:
  extensions:
  - !core/extension_metadata-1.0.0
    extension_class: asdf.extension._manifest.ManifestExtension
    extension_uri: asdf://asdf-format.org/core/extensions/core-1.5.0
    software: !core/software-1.0.0 {name: asdf, version: 3.0.0.dev591+g3c724f15}
...
```
note the `asdf` software marked in the list of extensions in the history metadata.

Writing a file with an astropy Unit results in the following file:
```yaml
#ASDF 1.0.0
#ASDF_STANDARD 1.5.0
%YAML 1.1
%TAG ! tag:stsci.edu:asdf/
--- !core/asdf-1.1.0
asdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: 'http://github.com/asdf-format/asdf',
  name: asdf, version: 3.0.0.dev591+g3c724f15}
history:
  extensions:
  - !core/extension_metadata-1.0.0
    extension_class: asdf_astropy._manifest.CompoundManifestExtension
    extension_uri: asdf://asdf-format.org/core/extensions/core-1.5.0
    software: !core/software-1.0.0 {name: asdf-astropy, version: 0.4.1.dev46+g38f76e1.d20230831}
u: !unit/unit-1.0.0 m
...
```
note that the `asdf` extension is no longer listed.

This PR modifies the extension uri defined for asdf-astropy core extensions to be unique (replacing `asdf-format` in the uri with `astropy`), allowing asdf to include both softwares in the file history. The single unit file above generated with the changes included in this PR is as follows:
```yaml
#ASDF 1.0.0
#ASDF_STANDARD 1.5.0
%YAML 1.1
%TAG ! tag:stsci.edu:asdf/
--- !core/asdf-1.1.0
asdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: 'http://github.com/asdf-format/asdf',
  name: asdf, version: 3.0.0.dev612+ge428962d}
history:
  extensions:
  - !core/extension_metadata-1.0.0
    extension_class: asdf.extension._manifest.ManifestExtension
    extension_uri: asdf://asdf-format.org/core/extensions/core-1.5.0
    software: !core/software-1.0.0 {name: asdf, version: 3.0.0.dev612+ge428962d}
  - !core/extension_metadata-1.0.0
    extension_class: asdf_astropy._manifest.CompoundManifestExtension
    extension_uri: asdf://astropy.org/core/extensions/core-1.5.0
    software: !core/software-1.0.0 {name: asdf-astropy, version: 0.4.1.dev46+g38f76e1.d20230831}
u: !unit/unit-1.0.0 m
...
```

A test was added (which does something similar to the above examples) to check for future regressions of the issue fixed in this PR.

Adding the above mentioned test revealed an issue with `test_no_astropy_import`. This needed to be addressed as depending on the test order the newly added test would fail on`import astropy.units` due to the bug in `test_no_astropy_import`. The modifications to `sys.modules` in `test_no_astropy_import` were changed to fix the bug. See the commit message for more details: 88be68c9638fb00ead1ef3e4036969faf4c7b029

`py39-test-oldestdep-parallels-cov` was also added to tox.ini as it otherwise will not run with the current tox.