### PR TITLE
add NdarrayMixin support, bump astropy extension version to 1.1.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@
 - Remove ``oldest-supported-numpy`` from ``pyproject.toml`` ``build-system``
   as this was never needed and will cause problems building on python 3.12 betas. [#193]
 - Use unique uri for extensions that implement converters for core asdf types [#199]
+- Add support for astropy.table.NdarrayMixin [#200]
 
 0.4.0 (2023-03-20)
 ------------------

--- a/asdf_astropy/converters/__init__.py
+++ b/asdf_astropy/converters/__init__.py
@@ -18,6 +18,7 @@ __all__ = [
     "ColumnConverter",
     "AstropyTableConverter",
     "AsdfTableConverter",
+    "NdarrayMixinConverter",
     "TimeDeltaConverter",
     "TimeConverter",
     "CompoundConverter",
@@ -51,7 +52,7 @@ from .coordinates import (
     SpectralCoordConverter,
 )
 from .fits import AsdfFitsConverter, AstropyFitsConverter, FitsConverter
-from .table import AsdfTableConverter, AstropyTableConverter, ColumnConverter
+from .table import AsdfTableConverter, AstropyTableConverter, ColumnConverter, NdarrayMixinConverter
 from .time import TimeConverter, TimeDeltaConverter
 from .transform import (
     CompoundBoundingBoxConverter,

--- a/asdf_astropy/converters/table/__init__.py
+++ b/asdf_astropy/converters/table/__init__.py
@@ -2,6 +2,7 @@ __all__ = [
     "ColumnConverter",
     "AstropyTableConverter",
     "AsdfTableConverter",
+    "NdarrayMixinConverter",
 ]
 
-from .table import AsdfTableConverter, AstropyTableConverter, ColumnConverter
+from .table import AsdfTableConverter, AstropyTableConverter, ColumnConverter, NdarrayMixinConverter

--- a/asdf_astropy/converters/table/table.py
+++ b/asdf_astropy/converters/table/table.py
@@ -88,3 +88,21 @@ class AstropyTableConverter(Converter):
             table[name] = column
 
         return table
+
+
+class NdarrayMixinConverter(Converter):
+    tags = ("tag:astropy.org:astropy/table/ndarraymixin-*",)
+    types = ("astropy.table.ndarray_mixin.NdarrayMixin",)
+
+    def to_yaml_tree(self, obj, tag, ctx):
+        import numpy as np
+
+        return {"array": np.asarray(obj)}
+
+    def from_yaml_tree(self, node, tag, ctx):
+        from astropy.table import NdarrayMixin
+
+        arr = node["array"]
+
+        # this will trigger reading the ASDF block that contains the array data
+        return arr.view(NdarrayMixin)

--- a/asdf_astropy/converters/table/tests/test_table.py
+++ b/asdf_astropy/converters/table/tests/test_table.py
@@ -219,7 +219,8 @@ def test_ndarray_mixin(tmp_path):
     table["b"] = ["x", "y"]
     table["c"] = NdarrayMixin([5, 6])
 
-    helpers.assert_table_roundtrip(table, tmp_path)
+    result = helpers.assert_table_roundtrip(table, tmp_path)
+    assert isinstance(result["c"], NdarrayMixin)
 
 
 def test_asdf_table():

--- a/asdf_astropy/extensions.py
+++ b/asdf_astropy/extensions.py
@@ -14,7 +14,7 @@ from .converters.coordinates.representation import RepresentationConverter
 from .converters.coordinates.sky_coord import SkyCoordConverter
 from .converters.coordinates.spectral_coord import SpectralCoordConverter
 from .converters.fits.fits import AsdfFitsConverter, AstropyFitsConverter
-from .converters.table.table import AsdfTableConverter, AstropyTableConverter, ColumnConverter
+from .converters.table.table import AsdfTableConverter, AstropyTableConverter, ColumnConverter, NdarrayMixinConverter
 from .converters.time.time import TimeConverter
 from .converters.time.time_delta import TimeDeltaConverter
 from .converters.transform.compound import CompoundConverter
@@ -40,7 +40,7 @@ __all__ = [
     "COORDINATES_CONVERTERS",
     "ASTROPY_CONVERTERS",
     "COORDINATES_EXTENSION",
-    "ASTROPY_EXTENSION",
+    "ASTROPY_EXTENSIONS",
     "CORE_CONVERTERS",
     "CORE_MANIFEST_URIS",
     "CORE_EXTENSIONS",
@@ -481,6 +481,7 @@ ASTROPY_CONVERTERS = [
     TimeDeltaConverter(),
     AstropyTableConverter(),
     AstropyFitsConverter(),
+    NdarrayMixinConverter(),
 ]
 
 
@@ -490,13 +491,22 @@ COORDINATES_EXTENSION = ManifestExtension.from_uri(
 )
 
 
-ASTROPY_EXTENSION = ManifestExtension.from_uri(
+_ASTROPY_EXTENSION_MANIFEST_URIS = [
+    "asdf://astropy.org/astropy/manifests/astropy-1.1.0",
     "asdf://astropy.org/astropy/manifests/astropy-1.0.0",
-    # This prevents a warning about a missing extension when opening
-    # files written by older versions of astropy:
-    legacy_class_names=["astropy.io.misc.asdf.extension.AstropyExtension"],
-    converters=ASTROPY_CONVERTERS,
-)
+]
+
+
+ASTROPY_EXTENSIONS = [
+    ManifestExtension.from_uri(
+        manifest_uri,
+        # This prevents a warning about a missing extension when opening
+        # files written by older versions of astropy:
+        legacy_class_names=["astropy.io.misc.asdf.extension.AstropyExtension"],
+        converters=ASTROPY_CONVERTERS,
+    )
+    for manifest_uri in _ASTROPY_EXTENSION_MANIFEST_URIS
+]
 
 # These tags are part of the ASDF Standard,
 # but we want to override serialization here so that users can

--- a/asdf_astropy/integration.py
+++ b/asdf_astropy/integration.py
@@ -36,7 +36,7 @@ def get_extensions():
     from . import extensions
 
     return [
-        extensions.ASTROPY_EXTENSION,
+        *extensions.ASTROPY_EXTENSIONS,
         extensions.COORDINATES_EXTENSION,
         *extensions.TRANSFORM_EXTENSIONS,
         *extensions.CORE_EXTENSIONS,

--- a/asdf_astropy/resources/manifests/astropy-1.1.0.yaml
+++ b/asdf_astropy/resources/manifests/astropy-1.1.0.yaml
@@ -1,0 +1,56 @@
+id: asdf://astropy.org/astropy/manifests/astropy-1.1.0
+extension_uri: asdf://astropy.org/astropy/extensions/astropy-1.1.0
+title: Astropy extension 1.1.0
+description: |-
+  A set of tags for serializing astropy objects.  This does not include most
+  model classes, which are handled by an implementation of the ASDF
+  transform extension.
+asdf_standard_requirement:
+  gte: 1.1.0
+tags:
+- tag_uri: tag:astropy.org:astropy/time/timedelta-1.0.0
+  schema_uri: http://astropy.org/schemas/astropy/time/timedelta-1.0.0
+  title: Represents an instance of TimeDelta from astropy
+  description: |-
+    Represents the time difference between two times.
+- tag_uri: tag:astropy.org:astropy/fits/fits-1.0.0
+  schema_uri: http://astropy.org/schemas/astropy/fits/fits-1.0.0
+  title: A FITS file inside of an ASDF file.
+  description: |-
+    This schema is useful for distributing ASDF files that can
+    automatically be converted to FITS files by specifying the exact
+    content of the resulting FITS file.
+
+    Not all kinds of data in FITS are directly representable in ASDF.
+    For example, applying an offset and scale to the data using the
+    `BZERO` and `BSCALE` keywords.  In these cases, it will not be
+    possible to store the data in the native format from FITS and also
+    be accessible in its proper form in the ASDF file.
+
+    Only image and binary table extensions are supported.
+- tag_uri: tag:astropy.org:astropy/table/table-1.1.0
+  schema_uri: http://astropy.org/schemas/astropy/table/table-1.1.0
+  title: A table.
+  description: |-
+    A table is represented as a list of columns, where each entry is a
+    [column](ref:http://stsci.edu/schemas/asdf/core/column-1.0.0)
+    object, containing the data and some additional information.
+
+    The data itself may be stored inline as text, or in binary in either
+    row- or column-major order by use of the `strides` property on the
+    individual column arrays.
+
+    Each column in the table must have the same first (slowest moving)
+    dimension.
+- tag_uri: tag:astropy.org:astropy/transform/units_mapping-1.0.0
+  schema_uri: http://astropy.org/schemas/astropy/transform/units_mapping-1.0.0
+  title: Mapper that operates on the units of the input.
+  description: |-
+    This transform operates on the units of the input, first converting to
+    the expected input units, then assigning replacement output units without
+    further conversion.
+- tag_uri: tag:astropy.org:astropy/table/ndarraymixin-1.0.0
+  schema_uri: http://astropy.org/schemas/astropy/table/ndarraymixin-1.0.0
+  title: NdarrayMixin column.
+  description: |-
+    Represents an astropy.table.NdarrayMixin instance.

--- a/asdf_astropy/resources/schemas/table/ndarraymixin-1.0.0.yaml
+++ b/asdf_astropy/resources/schemas/table/ndarraymixin-1.0.0.yaml
@@ -1,0 +1,17 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/table/ndarraymixin-1.0.0"
+
+title: >
+  title: NdarrayMixin column.
+
+description: |
+  Represents an astropy.table.NdarrayMixin instance.
+
+type: object
+properties:
+  array:
+    tag: "tag:stsci.edu:asdf/core/ndarray-*"
+additionalProperties: false
+required: [array]

--- a/asdf_astropy/resources/schemas/table/table-1.1.0.yaml
+++ b/asdf_astropy/resources/schemas/table/table-1.1.0.yaml
@@ -1,0 +1,130 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/table/table-1.1.0"
+
+title: >
+  A table.
+
+description: |
+  A table is represented as a list of columns, where each entry is a
+  [column](https://asdf-standard.readthedocs.io/en/latest/generated/stsci.edu/asdf/core/column-1.0.0.html)
+  object, containing the data and some additional information.
+
+  The data itself may be stored inline as text, or in binary in either
+  row- or column-major order by use of the `strides` property on the
+  individual column arrays.
+
+  Each column in the table must have the same first (slowest moving)
+  dimension.
+
+examples:
+  -
+    - A table stored in column-major order, with each column in a separate block
+    - |
+        !<tag:astropy.org:astropy/table/table-1.1.0>
+          columns:
+          - !core/column-1.0.0
+            data: !core/ndarray-1.0.0
+              source: 0
+              datatype: float64
+              byteorder: little
+              shape: [3]
+            description: RA
+            meta: {foo: bar}
+            name: a
+            unit: !unit/unit-1.0.0 deg
+          - !core/column-1.0.0
+            data: !core/ndarray-1.0.0
+              source: 1
+              datatype: float64
+              byteorder: little
+              shape: [3]
+            description: DEC
+            name: b
+          - !core/column-1.0.0
+            data: !core/ndarray-1.0.0
+              source: 2
+              datatype: [ascii, 1]
+              byteorder: big
+              shape: [3]
+            description: The target name
+            name: c
+          colnames: [a, b, c]
+
+  -
+    - A table stored in row-major order, all stored in the same block
+    - |
+        !<tag:astropy.org:astropy/table/table-1.1.0>
+          columns:
+          - !core/column-1.0.0
+            data: !core/ndarray-1.0.0
+              source: 0
+              datatype: float64
+              byteorder: little
+              shape: [3]
+              strides: [13]
+            description: RA
+            meta: {foo: bar}
+            name: a
+            unit: !unit/unit-1.0.0 deg
+          - !core/column-1.0.0
+            data: !core/ndarray-1.0.0
+              source: 0
+              datatype: float64
+              byteorder: little
+              shape: [3]
+              offset: 4
+              strides: [13]
+            description: DEC
+            name: b
+          - !core/column-1.0.0
+            data: !core/ndarray-1.0.0
+              source: 0
+              datatype: [ascii, 1]
+              byteorder: big
+              shape: [3]
+              offset: 12
+              strides: [13]
+            description: The target name
+            name: c
+          colnames: [a, b, c]
+
+type: object
+properties:
+  columns:
+    description: |
+      A list of columns in the table.
+    type: array
+    items:
+      anyOf:
+        - $ref: "http://stsci.edu/schemas/asdf/core/column-1.0.0"
+        - $ref: "http://stsci.edu/schemas/asdf/core/ndarray-1.0.0"
+        - $ref: "http://stsci.edu/schemas/asdf/time/time-1.1.0"
+        - $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.1.0"
+        - $ref: "../coordinates/skycoord-1.0.0"
+        - $ref: "../coordinates/earthlocation-1.0.0"
+        - $ref: "../time/timedelta-1.0.0"
+        - $ref: "ndarraymixin-1.0.0"
+
+  colnames:
+    description: |
+      A list containing the names of the columns in the table (in order).
+    type: array
+    items:
+      - type: string
+
+  qtable:
+    description: |
+      A flag indicating whether or not the serialized type was a QTable
+    type: boolean
+    default: False
+
+  meta:
+    description: |
+      Additional free-form metadata about the table.
+    type: object
+    default: {}
+
+additionalProperties: false
+required: [columns, colnames]


### PR DESCRIPTION
asdf 3.0 will warn when a ndarray subclass instance is converted using the ndarray converter as is done in the `test_ndarray_mixin` test:
https://github.com/astropy/asdf-astropy/blob/153b31c848750c8dabe2ac566caea333a47975a6/asdf_astropy/converters/table/tests/test_table.py#L216-L222

This PR adds `NdarrayMixinConverter` (and a corresponding tag and schema) to both prevent the warning and to allow round-tripping `NdarrayMixin` instances.

This PR updates the table schema (1.1.0) to reference the new ndarraymixin schema. These updates are included in a new version (1.1.0) of the astropy extension.