### PR TITLE
Ignore `GeneralSersic2D` model until astropy 6 comes out.

### DIFF
--- a/asdf_astropy/converters/transform/tests/test_transform.py
+++ b/asdf_astropy/converters/transform/tests/test_transform.py
@@ -485,6 +485,9 @@ if minversion("astropy", "5.1") and not minversion("asdf-transform-schemas", "0.
 if minversion("astropy", "5.1") and not minversion("asdf_transform_schemas", "0.2.2", inclusive=False):
     UNSUPPORTED_MODELS.append(astropy.modeling.powerlaws.Schechter1D)
 
+if minversion("astropy", "6.0.dev"):
+    UNSUPPORTED_MODELS.append(astropy.modeling.functional_models.GeneralSersic2D)
+
 
 @pytest.mark.parametrize("model", create_single_models())
 def test_single_model(tmp_path, model):


### PR DESCRIPTION
astropy/astropy#15545 added the `GeneralSersic2D` model. There currently is not a schema for it until asdf-format/asdf#109 is merged and released along side `astropy` 6.0. This PR ignores this model when testing until upstream support is provided.