### PR TITLE
Update `copy` usage in `Quantity` converter to deal with astropy 6.1 changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,7 @@ jobs:
       envs: |
         - linux: py39-parallel-cov
         - linux: py311-test-devdeps-parallel-cov
-        - linux: py39-astropylts-parallel-cov
-        - linux: py39-transformlts-parallel-cov
+        - linux: py312-test-predeps-parallel-cov
       coverage: codecov
 
   asdf-schemas:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+0.6.1 (unreleased)
+------------------
+
+- update ``copy`` usage in ``Quantity`` converter to
+  deal with astropy 6.1 changes. [#224]
+
 0.6.0 (2024-03-13)
 ------------------
 

--- a/asdf_astropy/converters/unit/quantity.py
+++ b/asdf_astropy/converters/unit/quantity.py
@@ -23,7 +23,13 @@ class QuantityConverter(Converter):
         return node
 
     def from_yaml_tree(self, node, tag, ctx):
+        # numpy 2.0 changed behavior for copy where an error is produced
+        # if False and a copy is required (previously there was no error)
+        # astropy 6.1 changed Quantity in a similar way
+        import numpy as np
         from astropy.units import Quantity
+
+        copy = None if np.lib.NumpyVersion(np.__version__) >= "2.0.0b1" else False
 
         value = node["value"]
         dtype = node.get("datatype", None)
@@ -33,4 +39,4 @@ class QuantityConverter(Converter):
             value = value._make_array()
             dtype = value.dtype
 
-        return Quantity(value, unit=node["unit"], copy=False, dtype=dtype)
+        return Quantity(value, unit=node["unit"], copy=copy, dtype=dtype)

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ envlist =
     py{39,310}-test{,-alldeps}
     py38-test-devdeps{,-numpydev}
     py38-cov
-    py38-astropylts
     py39-test-oldestdep-parallels-cov
 requires =
     setuptools >= 30.3.0
@@ -17,16 +16,17 @@ description =
     alldeps: with all optional dependencies
     devdeps: with the latest developer version of key dependencies
     cov: and test coverage
-    astropylts: with astropy LTS
 
 setenv =
     devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 
+pip_pre =
+    predeps: true
+    !predeps: false
+
 # The following provides some specific pinnings for key packages
 deps =
     cov: coverage
-    astropylts: astropy==5.0.*
-    transformlts: asdf-transform-schemas==0.2.*
 
     devdeps: -rrequirements-dev.txt
     oldestdeps: minimum_dependencies
@@ -39,8 +39,8 @@ commands_pre=
     numpydev: pip install -U --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
     numpydev: pip install -U --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy
     devdeps: pip install -U --pre -i https://pypi.anaconda.org/liberfa/simple pyerfa
-    #devdeps: pip install -U --pre -i https://pypi.anaconda.org/astropy/simple astropy
-    #devdeps: pip install -U git+https://github.com/astropy/astropy
+    devdeps: pip install -U --pre -i https://pypi.anaconda.org/astropy/simple astropy
+    predeps: pip install -U --pre -i https://pypi.anaconda.org/liberfa/simple pyerfa
 
     # Generate `requiremments-min.txt`
     oldestdeps: minimum_dependencies asdf-astropy --filename {envtmpdir}/requirements-min.txt

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ requires =
     pip >= 19.3.1
 isolated_build = true
 
+
 [testenv]
 description =
     run tests
@@ -38,7 +39,8 @@ commands_pre=
     numpydev: pip install -U --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
     numpydev: pip install -U --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy
     devdeps: pip install -U --pre -i https://pypi.anaconda.org/liberfa/simple pyerfa
-    devdeps: pip install -U --pre -i https://pypi.anaconda.org/astropy/simple astropy
+    #devdeps: pip install -U --pre -i https://pypi.anaconda.org/astropy/simple astropy
+    #devdeps: pip install -U git+https://github.com/astropy/astropy
 
     # Generate `requiremments-min.txt`
     oldestdeps: minimum_dependencies asdf-astropy --filename {envtmpdir}/requirements-min.txt

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,6 @@ commands_pre=
     numpydev: pip install -U --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy
     devdeps: pip install -U --pre -i https://pypi.anaconda.org/liberfa/simple pyerfa
     devdeps: pip install -U --pre -i https://pypi.anaconda.org/astropy/simple astropy
-    predeps: pip install -U --pre -i https://pypi.anaconda.org/liberfa/simple pyerfa
 
     # Generate `requiremments-min.txt`
     oldestdeps: minimum_dependencies asdf-astropy --filename {envtmpdir}/requirements-min.txt


### PR DESCRIPTION
astropy 6.1 changed the behavior of `copy`:
https://github.com/astropy/astropy/pull/16198

This breaks the `Quantity` converter and was not caught due to the `devdeps` testing against astropy "nightlies" which haven't been updated.

This PR adds a version check against numpy since that is the core source of the error (it looks like astropy will just pass es through `copy` to `array` instead of selectively calling `asarray`).

This PR also updates the CI to:
- remove astropy and transform 'lts' testing since 'lts' no longer exists
- adds a `predeps` job that runs against pre-releases

The masked array failure in the `predeps` should be fixed by:
https://github.com/asdf-format/asdf/pull/1769
which has not yet been released.