### PR TITLE
Strip `factor=None` in equivalency converter for spectral density

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+0.6.2 (unreleased)
+------------------
+
+- strip None factor for spectral_density in equivalency converter
+  to avoid deprecation warnings for astropy 7. [#229]
+
+
 0.6.1 (2024-04-05)
 ------------------
 

--- a/asdf_astropy/converters/unit/equivalency.py
+++ b/asdf_astropy/converters/unit/equivalency.py
@@ -21,6 +21,9 @@ class EquivalencyConverter(Converter):
             equivalency_method = with_H0 if name == "with_H0" else getattr(equivalencies, name)
 
             kwargs = dict(zip(equivalency_node["kwargs_names"], equivalency_node["kwargs_values"]))
+            # astropy 7.0 deprecated factor, if it's None, don't provide it to spectral_density
+            if "factor" in kwargs and name == "spectral_density" and kwargs["factor"] is None:
+                del kwargs["factor"]
             components.append(equivalency_method(**kwargs))
 
         # The Equivalency class is a UserList that overrides __add__ to

--- a/asdf_astropy/converters/unit/tests/test_equivalency.py
+++ b/asdf_astropy/converters/unit/tests/test_equivalency.py
@@ -12,7 +12,6 @@ def create_equivalencies():
     result = [
         eq.plate_scale(0.3 * u.deg / u.mm),
         eq.pixel_scale(0.5 * u.deg / u.pix),
-        eq.spectral_density(350 * u.nm, factor=2),
         eq.spectral_density(350 * u.nm),
         eq.spectral(),
         eq.brightness_temperature(500 * u.GHz),
@@ -39,6 +38,10 @@ def create_equivalencies():
     if Version(astropy.__version__) >= Version("4.1"):
         result.append(eq.pixel_scale(100.0 * u.pix / u.cm))
 
+    # the factor argument to spectral density is deprecated in astropy 7
+    # skip this test to avoid test failures due to the deprecation warning
+    if Version(astropy.__version__) < Version("7.0.0.dev"):
+        result.append(eq.spectral_density(350 * u.nm, factor=2))
     return result
 
 


### PR DESCRIPTION
Equivalencies are serialized by storing the `kwargs`:
https://github.com/astropy/asdf-astropy/blob/1b286108042c1201199e9931cd2a5b52cc57bdce/asdf_astropy/resources/schemas/units/equivalency-1.1.0.yaml#L19

The `factor` keyword argument to `spectral_density` is deprecated in astropy 7.0 which means:
- any file that contains a `spectral_density` that was originally created with a `factor` will produce a warning when loaded
- these files will be unreadable when `factor` is removed

This PR strip `factor` when it's `None` to avoid the deprecation warning for astropy 7 and only tests `factor` for astropy versions older than 7.