### PR TITLE
replace usages of ``copy_arrays`` with ``memmap`` for ``asdf>=3.1.0``

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@
 
 - drop support for python 3.9. [#232]
 
+- replace usages of ``copy_arrays`` with ``memmap`` [#230]
 
 0.6.1 (2024-04-05)
 ------------------

--- a/asdf_astropy/converters/unit/tests/test_quantity.py
+++ b/asdf_astropy/converters/unit/tests/test_quantity.py
@@ -1,16 +1,15 @@
-import importlib.metadata
-
 import asdf
 import numpy as np
 import pytest
 from asdf.testing import helpers
 from astropy import units
 from astropy.units import Quantity
+from astropy.utils.introspection import minversion
 from numpy.testing import assert_array_equal
 
 
 def asdf_open_memory_mapping_kwarg(memmap: bool) -> dict:
-    if tuple(int(part) for part in importlib.metadata.version("asdf").split(".")) >= (3, 1, 0):
+    if minversion("asdf", "3.1.0"):
         return {"memmap": memmap}
     else :
         return {"copy_arrays": not memmap}

--- a/asdf_astropy/converters/unit/tests/test_quantity.py
+++ b/asdf_astropy/converters/unit/tests/test_quantity.py
@@ -11,8 +11,7 @@ from numpy.testing import assert_array_equal
 def asdf_open_memory_mapping_kwarg(memmap: bool) -> dict:
     if minversion("asdf", "3.1.0"):
         return {"memmap": memmap}
-    else:
-        return {"copy_arrays": not memmap}
+    return {"copy_arrays": not memmap}
 
 
 def create_quantities():

--- a/asdf_astropy/converters/unit/tests/test_quantity.py
+++ b/asdf_astropy/converters/unit/tests/test_quantity.py
@@ -11,7 +11,7 @@ from numpy.testing import assert_array_equal
 def asdf_open_memory_mapping_kwarg(memmap: bool) -> dict:
     if minversion("asdf", "3.1.0"):
         return {"memmap": memmap}
-    else :
+    else:
         return {"copy_arrays": not memmap}
 
 
@@ -136,7 +136,7 @@ def test_no_memmap(tmp_path):
         af.write_to(file_path)
 
     # Update a value in the ASDF file
-    with asdf.open(file_path, mode="rw", asdf_open_memory_mapping_kwarg(memmap=False)) as af:
+    with asdf.open(file_path, mode="rw", **asdf_open_memory_mapping_kwarg(memmap=False)) as af:
         assert (af.tree["quantity"] == quantity).all()
         assert af.tree["quantity"][-1, -1] != new_value
 
@@ -146,7 +146,7 @@ def test_no_memmap(tmp_path):
         assert (af.tree["quantity"] != quantity).any()
         assert (af.tree["quantity"] == new_quantity).all()
 
-    with asdf.open(file_path, mode="rw", asdf_open_memory_mapping_kwarg(memmap=False)) as af:
+    with asdf.open(file_path, mode="rw", **asdf_open_memory_mapping_kwarg(memmap=False)) as af:
         assert af.tree["quantity"][-1, -1] != new_value
         assert (af.tree["quantity"] != new_quantity).any()
         assert (af.tree["quantity"] == quantity).all()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ extend-ignore = [
     "FIX", # flake8-fixme
     # Individually ignored checks
     "SLF001", # private-member-access
+    "FBT001", # boolean positional arguments in function definition
 ]
 extend-exclude = ["docs/*"]
 


### PR DESCRIPTION
follow-on to https://github.com/asdf-format/asdf/pull/1797