### PR TITLE
drop py39 try to fix oldestdeps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,9 @@ jobs:
       cache-restore-keys: |
         pip-
       # Any env name which does not start with `pyXY` will use this Python version.
-      default_python: '3.9'
+      default_python: '3.12'
       envs: |
-        - linux: py39-parallel-cov
+        - linux: py310-test-parallel-cov
         - linux: py311-test-devdeps-parallel-cov
         - linux: py312-test-predeps-parallel-cov
       coverage: codecov
@@ -50,7 +50,7 @@ jobs:
       cache-key: pip-${{ needs.setup.outputs.requirements-hash }}
       cache-restore-keys: |
         pip-
-      default_python: '3.10'
+      default_python: '3.12'
       envs: |
         - linux: asdf
         - linux: asdf-standard
@@ -66,7 +66,7 @@ jobs:
       cache-restore-keys: |
         pip-
       # Any env name which does not start with `pyXY` will use this Python version.
-      default_python: '3.10'
+      default_python: '3.12'
       envs: |
         - linux: py310-test-parallel
         - linux: py311-test-parallel
@@ -83,7 +83,7 @@ jobs:
       cache-restore-keys: |
         pip-
       # Any env name which does not start with `pyXY` will use this Python version.
-      default_python: '3.9'
+      default_python: '3.12'
       envs: |
         - linux: py310-test-devdeps-parallel
         - linux: py311-test-devdeps-parallel
@@ -98,9 +98,9 @@ jobs:
       cache-restore-keys: |
         pip-
       # Any env name which does not start with `pyXY` will use this Python version.
-      default_python: '3.9'
+      default_python: '3.10'
       envs: |
-        - linux: py39-test-oldestdep-parallels-cov
+        - linux: py310-test-oldestdeps-parallel-cov
       coverage: codecov
 
   wheel_building:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,7 @@ build:
   apt_packages:
     - graphviz
   tools:
-    python: "3.9"
+    python: "3.12"
 
 sphinx:
   fail_on_warning: true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 - strip None factor for spectral_density in equivalency converter
   to avoid deprecation warnings for astropy 7. [#229]
 
+- drop support for python 3.9. [#232]
+
 
 0.6.1 (2024-04-05)
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
   "asdf-coordinates-schemas>=0.3",
   "asdf-transform-schemas>=0.5",
   "asdf-standard>=1.1.0",
-  "astropy>=5.0.4",
+  "astropy>=6.0.0",
   "numpy>=1.24",
   "packaging>=19",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,11 @@ description = "ASDF serialization support for astropy"
 readme = 'README.rst'
 license = { file = 'LICENSE.rst' }
 authors = [{ name = 'The Astropy Developers', email = 'astropy.team@gmail.com' }]
-requires-python = '>=3.9'
+requires-python = '>=3.10'
 classifiers = [
   'Development Status :: 5 - Production/Stable',
   'Programming Language :: Python',
   "Programming Language :: Python :: 3 :: Only",
-  'Programming Language :: Python :: 3.9',
   'Programming Language :: Python :: 3.10',
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -23,7 +22,7 @@ dependencies = [
   "asdf-transform-schemas>=0.5",
   "asdf-standard>=1.1.0",
   "astropy>=5.0.4",
-  "numpy>=1.20",
+  "numpy>=1.24",
   "packaging>=19",
 ]
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
   "asdf-coordinates-schemas>=0.3",
   "asdf-transform-schemas>=0.5",
   "asdf-standard>=1.1.0",
-  "astropy>=6.0.0",
+  "astropy>=5.2.0",
   "numpy>=1.24",
   "packaging>=19",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,6 @@
 [tox]
 envlist =
-    py{39,310}-test{,-alldeps}
-    py38-test-devdeps{,-numpydev}
-    py38-cov
-    py39-test-oldestdep-parallels-cov
+    py{310,311,312}-test{,-devdeps,-predeps,-oldestdeps}{,-numpydev}{,-parallel}{,-cov}
 requires =
     setuptools >= 30.3.0
     pip >= 19.3.1


### PR DESCRIPTION
This PR drops a few old versions of:
- python, now >=3.10
- numpy, now >=1.24
- astropy, now >=5.2

This PR also fixes the oldestdeps job which appears to have never worked due to a typos, `oldestdep` instead of `oldestdeps` (and `parallels` instead of `parallel`):
https://github.com/astropy/asdf-astropy/blob/dab5b4d73ce3f75e60e5b29e75eb3e811dfd8319/.github/workflows/ci.yml#L103

When it `oldestdeps` working with this PR and the numpy version was bumped the CI showed failures due to the old astropy (5.0.4). These were addressed by bumping astropy to 5.2.0.

Fixes https://github.com/astropy/asdf-astropy/issues/231