### PR TITLE
Remove `astropy` version check

### DIFF
--- a/asdf_astropy/converters/transform/tests/test_transform.py
+++ b/asdf_astropy/converters/transform/tests/test_transform.py
@@ -77,24 +77,19 @@ def create_bounding_boxes():
             astropy_models.Polynomial2D(1),
             [("x", False)],
         ),
+        CompoundBoundingBox(
+            {(1,): (0, 1), (2,): (2, 3)},
+            astropy_models.Polynomial2D(1),
+            [("x", False)],
+            ignored=["x"],
+        ),
+        CompoundBoundingBox(
+            {(1,): (0, 1), (2,): (2, 3)},
+            astropy_models.Polynomial2D(1),
+            [("x", False)],
+            ignored=["y"],
+        ),
     ]
-    if minversion("astropy", "5.1"):
-        compound_bounding_box.extend(
-            [
-                CompoundBoundingBox(
-                    {(1,): (0, 1), (2,): (2, 3)},
-                    astropy_models.Polynomial2D(1),
-                    [("x", False)],
-                    ignored=["x"],
-                ),
-                CompoundBoundingBox(
-                    {(1,): (0, 1), (2,): (2, 3)},
-                    astropy_models.Polynomial2D(1),
-                    [("x", False)],
-                    ignored=["y"],
-                ),
-            ],
-        )
 
     return model_bounding_box + compound_bounding_box
 


### PR DESCRIPTION
The minimum required version of astropy is 5.2. 

https://github.com/astropy/asdf-astropy/blob/9348f899f57114b574b050ea59d3c74b28e498f6/pyproject.toml#L24

This PR removes the `if` check for the following:

https://github.com/astropy/asdf-astropy/blob/9348f899f57114b574b050ea59d3c74b28e498f6/asdf_astropy/converters/transform/tests/test_transform.py#L81

Originally discussed: #235