### PR TITLE
Cleanup, fix CI, remove out-dated version checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,8 @@ jobs:
       default_python: '3.12'
       envs: |
         - linux: py310-test-parallel-cov
-        - linux: py311-test-devdeps-parallel-cov
-        - linux: py312-test-predeps-parallel-cov
+        - linux: py311-test-parallel-cov
+        - linux: py312-test-parallel-cov
       coverage: codecov
 
   asdf-schemas:
@@ -68,9 +68,6 @@ jobs:
       # Any env name which does not start with `pyXY` will use this Python version.
       default_python: '3.12'
       envs: |
-        - linux: py310-test-parallel
-        - linux: py311-test-parallel
-        - linux: py312-test-parallel
         - macos: py311-test-parallel
         - windows: py311-test-parallel
 
@@ -85,9 +82,9 @@ jobs:
       # Any env name which does not start with `pyXY` will use this Python version.
       default_python: '3.12'
       envs: |
-        - linux: py310-test-devdeps-parallel
-        - linux: py311-test-devdeps-parallel
-        - linux: py311-test-devdeps-numpydev-parallel
+        - linux: py312-test-predeps-parallel
+        - linux: py313-test-devdeps-parallel
+        - linux: py312-test-devdeps-numpydev-parallel
 
   oldest:
     needs: [core, asdf-schemas]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@
 
 - replace usages of ``copy_arrays`` with ``memmap`` [#230]
 
+- require asdf 2.14.4 [#241]
+
 0.6.1 (2024-04-05)
 ------------------
 

--- a/asdf_astropy/converters/transform/core.py
+++ b/asdf_astropy/converters/transform/core.py
@@ -131,41 +131,18 @@ class TransformConverterBase(Converter):
 
     def _serialize_bbox(self, model, node):
         from astropy.modeling.bounding_box import ModelBoundingBox
-        from astropy.utils import minversion
 
         bbox = model.bounding_box
 
-        if minversion("asdf_transform_schemas", "0.2.2", inclusive=False):
-            if len(bbox.ignored) > 0:
-                if minversion("astropy", "5.1"):
-                    kwargs = {"_preserve_ignore": True}
-                else:
-                    msg = "Bounding box ignored arguments are only supported by astropy 5.1+"
-                    raise RuntimeError(msg)
-            else:
-                kwargs = {}
-
-            bbox = ModelBoundingBox.validate(model, bbox, **kwargs)
+        if len(bbox.ignored) > 0:
+            kwargs = {"_preserve_ignore": True}
         else:
-            if len(bbox.ignored) > 0:
-                msg = "asdf-transform-schemas > 0.2.2 in order to serialize a bounding_box with ignored"
-                raise RuntimeError(msg)
+            kwargs = {}
 
-            bbox = bbox.bounding_box(order="C")
-            bbox = list(bbox) if model.n_inputs == 1 else [list(item) for item in bbox]
-
-        node["bounding_box"] = bbox
+        node["bounding_box"] = ModelBoundingBox.validate(model, bbox, **kwargs)
 
     def _serialize_cbbox(self, model, node):
-        from astropy.utils import minversion
-
-        bbox = model.bounding_box
-
-        if minversion("asdf_transform_schemas", "0.2.2", inclusive=False):
-            node["bounding_box"] = bbox
-        else:
-            msg = "asdf-transform-schemas > 0.2.2 in order to serialize a compound bounding_box"
-            raise RuntimeError(msg)
+        node["bounding_box"] = model.bounding_box
 
     def from_yaml_tree(self, node, tag, ctx):
         from astropy.modeling.core import CompoundModel

--- a/asdf_astropy/converters/transform/properties.py
+++ b/asdf_astropy/converters/transform/properties.py
@@ -1,5 +1,4 @@
 from asdf.extension import Converter
-from astropy.utils import minversion
 
 
 class ModelBoundingBoxConverter(Converter):
@@ -31,8 +30,7 @@ class ModelBoundingBoxConverter(Converter):
                     set(ignored + [get_name(model, get_index(model, key)) for key in cbbox.selector_args.ignore]),
                 )
                 # Add in globally ignored inputs from the compound_bounding_box in 5.1+
-                if minversion("astropy", "5.1"):
-                    ignore = list(set(ignore + [get_name(model, get_index(model, key)) for key in cbbox.ignored]))
+                ignore = list(set(ignore + [get_name(model, get_index(model, key)) for key in cbbox.ignored]))
 
             return ModelBoundingBox(intervals, model, ignored=ignore, order=order)
 
@@ -50,8 +48,7 @@ class CompoundBoundingBoxConverter(Converter):
             "order": cbbox.order,
         }
 
-        if minversion("astropy", "5.1"):
-            node["ignore"] = cbbox.ignored_inputs
+        node["ignore"] = cbbox.ignored_inputs
 
         return node
 
@@ -66,16 +63,7 @@ class CompoundBoundingBoxConverter(Converter):
         order = node["order"] if "order" in node else "C"
 
         def create_bounding_box(model):
-            if not minversion("astropy", "5.1"):
-                if len(ignored) > 0:
-                    msg = (
-                        "Deserializing ignored elements of a compound bounding box is only supported for astropy 5.1+."
-                    )
-                    raise RuntimeError(msg)
-
-                cbbox = CompoundBoundingBox({}, model, selector_args, order=order)
-            else:
-                cbbox = CompoundBoundingBox({}, model, selector_args, ignored=ignored, order=order)
+            cbbox = CompoundBoundingBox({}, model, selector_args, ignored=ignored, order=order)
 
             for key, bb in bboxes.items():
                 cbbox[key] = bb(model, cbbox)

--- a/asdf_astropy/extensions.py
+++ b/asdf_astropy/extensions.py
@@ -4,7 +4,6 @@ via an ``entry-point`` in the ``pyproject.toml`` file.
 """
 
 from asdf.extension import ManifestExtension
-from astropy.utils import minversion
 
 from .converters.coordinates.angle import AngleConverter, LatitudeConverter, LongitudeConverter
 from .converters.coordinates.earth_location import EarthLocationConverter
@@ -385,16 +384,11 @@ TRANSFORM_CONVERTERS = [
     # astropy.modeling.bounding_box
     ModelBoundingBoxConverter(),
     CompoundBoundingBoxConverter(),
+    SimpleTransformConverter(
+        ["tag:stsci.edu:asdf/transform/schechter1d-*"],
+        "astropy.modeling.powerlaws.Schechter1D",
+    ),
 ]
-
-if minversion("astropy", "5.1.0"):
-    TRANSFORM_CONVERTERS.append(
-        SimpleTransformConverter(
-            ["tag:stsci.edu:asdf/transform/schechter1d-*"],
-            "astropy.modeling.powerlaws.Schechter1D",
-        ),
-    )
-
 
 # The order here is important; asdf will prefer to use extensions
 # that occur earlier in the list.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ extend-ignore = [
     "DTZ", # flake8-datetimez
     "TD", # flake8-todos
     "FIX", # flake8-fixme
+    "SIM", # flake8-simplify
     # Individually ignored checks
     "SLF001", # private-member-access
     "FBT001", # boolean positional arguments in function definition

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dynamic = [
   'version',
 ]
 dependencies = [
-  "asdf>=2.14",
+  "asdf>=2.14.4",
   "asdf-coordinates-schemas>=0.3",
   "asdf-transform-schemas>=0.5",
   "asdf-standard>=1.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ docs = [
 test = [
   "coverage",
   "pytest-astropy",
-  "scipy",
   "pytest",
 ]
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dynamic = [
   'version',
 ]
 dependencies = [
-  "asdf>=2.13",
+  "asdf>=2.14",
   "asdf-coordinates-schemas>=0.3",
   "asdf-transform-schemas>=0.5",
   "asdf-standard>=1.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ test = [
   "coverage",
   "pytest-astropy",
   "pytest",
+  "scipy",  # indirect requirement via astropy
 ]
 [project.urls]
 'documentation' = 'https://asdf-astropy.readthedocs.io/en/latest/'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,5 +3,4 @@ git+https://github.com/asdf-format/asdf-standard.git
 git+https://github.com/asdf-format/asdf-transform-schemas
 git+https://github.com/asdf-format/asdf-coordinates-schemas
 
-scipy>=0.0.dev0
 numpy>=0.0.dev0

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,8 @@ commands_pre=
 commands =
     pytest \
     parallel: --numprocesses auto \
-    cov: --cov-report xml --cov asdf_astropy
+    cov: --cov-report xml --cov asdf_astropy \
+    oldestdeps: -W ignore::DeprecationWarning
     {posargs}
 
 [testenv:asdf]

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,6 @@ extras =
     alldeps: all
 commands_pre=
     numpydev: pip install -U --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
-    numpydev: pip install -U --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy
     devdeps: pip install -U --pre -i https://pypi.anaconda.org/liberfa/simple pyerfa
     devdeps: pip install -U --pre -i https://pypi.anaconda.org/astropy/simple astropy
 

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,6 @@ commands =
     pytest \
     parallel: --numprocesses auto \
     cov: --cov-report xml --cov asdf_astropy \
-    oldestdeps: -W ignore::DeprecationWarning
     {posargs}
 
 [testenv:asdf]


### PR DESCRIPTION
Our `oldestdeps` and `devdeps` [CI](https://github.com/astropy/asdf-astropy/actions/runs/10988582459) are failing on main. This PR fixes the CI by:
- removing scipy dev installation. This is an indirect requirement via astropy (we use 0 scipy API). Their nightly wheels are currently broken and given our limited use it seems safe to me to not require a dev scipy version (since the latest released version works with nightly numpy).
- increasing the asdf minimum version. Something with the very old version of jsonschema pulled in by our minimum asdf wasn't playing nice with the CI. I first attempted to bump this to 2.14 but that failed due to a lack of a jsonschema upper pin. 2.14.4 has an upper pin and allows the `oldestdeps` to now pass. 2.14.4 was released Mar 20, 2023 but given the issues with older dependencies I'm ok with this bump.

I also went through and removed vestigial code only run for versions older than what we now support.
Fixes: https://github.com/astropy/asdf-astropy/issues/233

There are a few other very minor changes that I will call out in comments.

Note that some of the CI cleanup in this PR will require updates to our branch protection rules (for example the required `
test / py312-test-parallel` is no longer run and instead we can require `CI / core / py312-test-parallel-cov`).