### PR TITLE
skip Lorentz2D until it can be supported

### DIFF
--- a/asdf_astropy/converters/transform/tests/test_transform.py
+++ b/asdf_astropy/converters/transform/tests/test_transform.py
@@ -463,6 +463,9 @@ UNSUPPORTED_MODELS = [
 if minversion("astropy", "6.0.dev"):
     UNSUPPORTED_MODELS.append(astropy.modeling.functional_models.GeneralSersic2D)
 
+if minversion("astropy", "7.0.dev"):
+    UNSUPPORTED_MODELS.append(astropy.modeling.functional_models.Lorentz2D)
+
 
 @pytest.mark.parametrize("model", create_single_models())
 def test_single_model(tmp_path, model):


### PR DESCRIPTION
astropy added astropy.modeling.functional_models.Lorentz2D see https://github.com/astropy/asdf-astropy/issues/243

This PR adds the unsupported model to the list of unsupported models to fix the devdeps.

This PR does not close the associated issue as we'll need to:
- make a schema
- add the schema to asdf-transform-schemas
- add a converter to this package

so let's leave the issue open to track that work.