### PR TITLE
Update Python version support: drop 3.10, add 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,9 +95,9 @@ jobs:
       cache-restore-keys: |
         pip-
       # Any env name which does not start with `pyXY` will use this Python version.
-      default_python: '3.10'
+      default_python: '3.11'
       envs: |
-        - linux: py310-test-oldestdeps-parallel-cov
+        - linux: py311-test-oldestdeps-parallel-cov
       coverage: codecov
 
   wheel_building:

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -29,7 +29,7 @@ jobs:
     with:
       submodules: false
       # Any env name which does not start with `pyXY` will use this Python version.
-      default_python: '3.10'
+      default_python: '3.11'
       envs: |
         - linux: specutils
 
@@ -39,7 +39,7 @@ jobs:
     with:
       submodules: false
       # Any env name which does not start with `pyXY` will use this Python version.
-      default_python: '3.10'
+      default_python: '3.11'
       envs: |
         - linux: gwcs
         - linux: jwst
@@ -52,7 +52,7 @@ jobs:
     with:
       submodules: false
       # Any env name which does not start with `pyXY` will use this Python version.
-      default_python: '3.10'
+      default_python: '3.11'
       envs: |
         - linux: sunpy
         - linux: dkist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,14 @@ description = "ASDF serialization support for astropy"
 readme = 'README.rst'
 license = { file = 'LICENSE.rst' }
 authors = [{ name = 'The Astropy Developers', email = 'astropy.team@gmail.com' }]
-requires-python = '>=3.10'
+requires-python = '>=3.11'
 classifiers = [
   'Development Status :: 5 - Production/Stable',
   'Programming Language :: Python',
   "Programming Language :: Python :: 3 :: Only",
-  'Programming Language :: Python :: 3.10',
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 dynamic = [
   'version',
@@ -21,7 +21,7 @@ dependencies = [
   "asdf-coordinates-schemas>=0.3",
   "asdf-transform-schemas>=0.5",
   "asdf-standard>=1.1.0",
-  "astropy>=5.2.0",
+  "astropy>=7.0.0",
   "numpy>=1.24",
   "packaging>=19",
 ]
@@ -80,7 +80,7 @@ force-exclude = '''
 '''
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py311"
 line-length = 120
 select = ["ALL"]
 extend-ignore = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{310,311,312}-test{,-devdeps,-predeps,-oldestdeps}{,-numpydev}{,-parallel}{,-cov}
+    py{311,312,313}-test{,-devdeps,-predeps,-oldestdeps}{,-numpydev}{,-parallel}{,-cov}
 requires =
     setuptools >= 30.3.0
     pip >= 19.3.1


### PR DESCRIPTION
Align with the Python versions supported by Astropy 7.x.