### PR TITLE
register blank extensions for old files with modified extension uris

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,12 @@
 
 - drop support for python 3.10 and numpy 1.24. [#255]
 
+0.7.1 (unreleased)
+------------------
+
+- register blank ASDF extensions to prevent warnings for
+  ASDF files generated with asdf-astropy 0.5.0. [#258]
+
 0.7.0 (2024-11-13)
 ------------------
 

--- a/asdf_astropy/extensions.py
+++ b/asdf_astropy/extensions.py
@@ -3,7 +3,7 @@ This module builds all of the ASDF extensions which will be registered by `asdf_
 via an ``entry-point`` in the ``pyproject.toml`` file.
 """
 
-from asdf.extension import ManifestExtension
+from asdf.extension import Extension, ManifestExtension
 
 from .converters.coordinates.angle import AngleConverter, LatitudeConverter, LongitudeConverter
 from .converters.coordinates.earth_location import EarthLocationConverter
@@ -563,3 +563,32 @@ CORE_MANIFEST_URIS = [
 ]
 
 CORE_EXTENSIONS = [ManifestExtension.from_uri(u, converters=CORE_CONVERTERS) for u in CORE_MANIFEST_URIS]
+
+
+# asdf-astropy 0.4.0 combined core and unit manifests
+# but registered them with the core uri
+# asdf-astropy 0.5.0 combined core and unit manifests
+# but registered them with the core uri with asdf-format.org
+# swapped with astropy.org
+# To avoid warnings for opening old files we register empty
+# extensions with the astropy.org uris here
+class _EmptyExtension(Extension):
+    def __init__(self, uri):
+        self._uri = uri
+
+    @property
+    def extension_uri(self):
+        return self._uri
+
+
+EMPTY_EXTENSIONS = [
+    _EmptyExtension(uri)
+    for uri in [
+        "asdf://astropy.org/core/extensions/core-1.5.0",
+        "asdf://astropy.org/core/extensions/core-1.4.0",
+        "asdf://astropy.org/core/extensions/core-1.3.0",
+        "asdf://astropy.org/core/extensions/core-1.2.0",
+        "asdf://astropy.org/core/extensions/core-1.1.0",
+        "asdf://astropy.org/core/extensions/core-1.0.0",
+    ]
+]

--- a/asdf_astropy/integration.py
+++ b/asdf_astropy/integration.py
@@ -41,4 +41,5 @@ def get_extensions():
         *extensions.TRANSFORM_EXTENSIONS,
         *extensions.UNIT_EXTENSIONS,
         *extensions.CORE_EXTENSIONS,
+        *extensions.EMPTY_EXTENSIONS,
     ]

--- a/asdf_astropy/tests/test_integration.py
+++ b/asdf_astropy/tests/test_integration.py
@@ -1,5 +1,6 @@
 import io
 import sys
+import warnings
 from pathlib import Path
 
 import asdf
@@ -134,3 +135,40 @@ def test_no_core_extension_overwrite():
         # generate the file
         assert "asdf" in packages
         assert "asdf-astropy" in packages
+
+
+def test_no_warnings_for_astropy_manifest_files():
+    """
+    asdf-astropy 0.5.0 wrote files with astropy.org manifests
+    that were compounds of core and astropy types. These types are
+    now handled by different extensions. This test checks that files
+    generated with the no longer used astropy.org manifests open without
+    warnings.
+    """
+    file_contents = io.BytesIO(
+        b"""#ASDF 1.0.0
+#ASDF_STANDARD 1.5.0
+%YAML 1.1
+%TAG ! tag:stsci.edu:asdf/
+--- !core/asdf-1.1.0
+asdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: 'http://github.com/asdf-format/asdf',
+  name: asdf, version: 3.3.0}
+history:
+  extensions:
+  - !core/extension_metadata-1.0.0
+    extension_class: asdf.extension._manifest.ManifestExtension
+    extension_uri: asdf://asdf-format.org/core/extensions/core-1.5.0
+    manifest_software: !core/software-1.0.0 {name: asdf_standard, version: 1.1.1}
+    software: !core/software-1.0.0 {name: asdf, version: 3.3.0}
+  - !core/extension_metadata-1.0.0
+    extension_class: asdf_astropy._manifest.CompoundManifestExtension
+    extension_uri: asdf://astropy.org/core/extensions/core-1.5.0
+    software: !core/software-1.0.0 {name: asdf-astropy, version: 0.5.0}
+u: !unit/unit-1.0.0 m
+...""",
+    )
+    with warnings.catch_warnings():
+        # make sure warnings are errors
+        warnings.simplefilter("error")
+        with asdf.open(file_contents) as af:
+            assert af["u"]  # we don't care about the contents here


### PR DESCRIPTION
asdf-astropy 0.5.0 wrote files with a reported extension_uri containing astropy.org:
```yaml
#ASDF 1.0.0
#ASDF_STANDARD 1.5.0
%YAML 1.1
%TAG ! tag:stsci.edu:asdf/
--- !core/asdf-1.1.0
asdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: 'http://github.com/asdf-format/asdf',
  name: asdf, version: 3.3.0}
history:
  extensions:
  - !core/extension_metadata-1.0.0
    extension_class: asdf.extension._manifest.ManifestExtension
    extension_uri: asdf://asdf-format.org/core/extensions/core-1.5.0
    manifest_software: !core/software-1.0.0 {name: asdf_standard, version: 1.1.1}
    software: !core/software-1.0.0 {name: asdf, version: 3.3.0}
  - !core/extension_metadata-1.0.0
    extension_class: asdf_astropy._manifest.CompoundManifestExtension
    extension_uri: asdf://astropy.org/core/extensions/core-1.5.0
    software: !core/software-1.0.0 {name: asdf-astropy, version: 0.5.0}
u: !unit/unit-1.0.0 m
...
```
When loaded with asdf-astropy 0.7.0 this results in a warning:
```
... was created with extension URI 'asdf://astropy.org/core/extensions/core-1.5.0' (from package asdf-astropy==0.5.0), which is not currently installed
  warnings.warn(msg, AsdfPackageVersionWarning)
```
Since the `CompoundManifest` (which modified the `extension_uri`) is no longer being used and no extension_uris with `asdf://astropy.org/core/extensions/core-*` are registered. The types are still handled but the failure of asdf to find the exact extension_uri results in the warning.

To avoid these uninformative errors this PR registers blank extensions using the now unused extension uris. Note that since these are blank extensions they will never be recorded in new files but only prevent the warning when opening old files.

I added this to a 0.7.1 section of the changelog as the plan is to make a bugfix release with this fix by cherry picking it onto the release branch after this PR is merged.