### PR TITLE
reduce autoupdate to monthly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 ci:
 
   autofix_prs: false
+  autoupdate_schedule: monthly
 
 repos:
 


### PR DESCRIPTION
These default to weekly and every week we get an automatic PR to update ruff. This reduces the frequency of automatic updates to monthly to reduce the pace at which PRs become out-of-date due to weekly ruff updates.