### PR TITLE
Enable support for new transform and coordinates schemas

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@
 - drop support for python 3.10 and numpy 1.24. [#255]
 - remove soon to be deprecated and non-working use of astropy TestRunner. [#263]
 - Add support for masked quantities, angles, and coordinates for astropy >= 7.1. [#253]
+- Add support for asdf-transform-schemas 0.6 and asdf-coordinates-schemas 0.4. [#279]
 
 0.7.1 (2025-02-12)
 ------------------

--- a/asdf_astropy/extensions.py
+++ b/asdf_astropy/extensions.py
@@ -396,6 +396,7 @@ TRANSFORM_CONVERTERS = [
 # The order here is important; asdf will prefer to use extensions
 # that occur earlier in the list.
 TRANSFORM_MANIFEST_URIS = [
+    "asdf://asdf-format.org/transform/manifests/transform-1.7.0",
     "asdf://asdf-format.org/transform/manifests/transform-1.6.0",
     "asdf://asdf-format.org/transform/manifests/transform-1.5.0",
     "asdf://asdf-format.org/transform/manifests/transform-1.4.0",
@@ -485,6 +486,7 @@ ASTROPY_CONVERTERS = [
 ]
 
 _COORDINATES_MANIFEST_URIS = [
+    "asdf://asdf-format.org/astronomy/coordinates/manifests/coordinates-1.2.0",
     "asdf://asdf-format.org/astronomy/coordinates/manifests/coordinates-1.1.0",
     "asdf://asdf-format.org/astronomy/coordinates/manifests/coordinates-1.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dynamic = [
   'version',
 ]
 dependencies = [
-  "asdf>=2.14.4",
+  "asdf>=2.15.0",
   #"asdf-coordinates-schemas>=0.3",
   "asdf-coordinates-schemas @ git+https://github.com/asdf-format/asdf-coordinates-schemas",
   #"asdf-transform-schemas>=0.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,10 @@ dynamic = [
 ]
 dependencies = [
   "asdf>=2.14.4",
-  "asdf-coordinates-schemas>=0.3",
-  "asdf-transform-schemas>=0.5",
+  #"asdf-coordinates-schemas>=0.3",
+  "asdf-coordinates-schemas @ git+https://github.com/asdf-format/asdf-coordinates-schemas",
+  #"asdf-transform-schemas>=0.5",
+  "asdf-transform-schemas @ git+https://github.com/asdf-format/asdf-transform-schemas",
   "asdf-standard>=1.1.0",
   "astropy>=5.2.0",
   "numpy>=1.25",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,8 @@ dynamic = [
 ]
 dependencies = [
   "asdf>=2.15.0",
-  #"asdf-coordinates-schemas>=0.3",
-  "asdf-coordinates-schemas @ git+https://github.com/asdf-format/asdf-coordinates-schemas",
-  #"asdf-transform-schemas>=0.5",
-  "asdf-transform-schemas @ git+https://github.com/asdf-format/asdf-transform-schemas",
+  "asdf-coordinates-schemas>=0.4",
+  "asdf-transform-schemas>=0.6",
   "asdf-standard>=1.1.0",
   "astropy>=5.2.0",
   "numpy>=1.25",


### PR DESCRIPTION
This PR adds support for the new asdf-transform and asdf-coordinates schemas. It will be brought out of draft when those packages are released and the pins can be set.