### PR TITLE
drop private API usage of _open_impl

### DIFF
--- a/asdf_astropy/converters/coordinates/tests/test_frame.py
+++ b/asdf_astropy/converters/coordinates/tests/test_frame.py
@@ -116,6 +116,5 @@ def test_legacy_icrs_deseialize():
     truth = ICRS(ra=Longitude(25, unit=u.deg), dec=Latitude(45, unit=u.deg))
 
     buff = yaml_to_asdf(f"example: {example.strip()}", version="1.5.0")
-    with asdf.AsdfFile() as af:
-        af._open_impl(af, buff, mode="rw")
+    with asdf.open(buff) as af:
         assert_frame_equal(af["example"], truth)

--- a/asdf_astropy/converters/time/tests/test_time.py
+++ b/asdf_astropy/converters/time/tests/test_time.py
@@ -112,8 +112,7 @@ def create_examples():
 @pytest.mark.parametrize("example", create_examples())
 def test_read_examples(example):
     buff = yaml_to_asdf(f"example: {example['example'].strip()}", version="1.5.0")
-    with asdf.AsdfFile() as af:
-        af._open_impl(af, buff, mode="rw")
+    with asdf.open(buff) as af:
         assert np.all(af["example"] == example["truth"])
 
 


### PR DESCRIPTION
Remove more private API usage from asdf.

In this case replace `AsdfFile._open_impl` with `asdf.open`.