### PR TITLE
use new pytest asdf plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ docs = [
 test = [
   "coverage",
   "pytest-astropy",
+  "pytest-asdf-plugin",
   "pytest",
   "scipy",  # indirect requirement via astropy
 ]


### PR DESCRIPTION
Update test dependencies to use new https://pypi.org/project/pytest-asdf-plugin/ which is a feature-compatible replacement for the bundled asdf pytest plugin (which will soon be deprecated).

For context the pytest-asdf-plugin is responsible for finding and converting schema files into "tests" (to check the schema against the metaschema and validated any contained "examples"). Since both the bundled and now external plugins are feature-compatible there should be no change in test number (or new failures, etc).

On main 4427 tests passed:
https://github.com/astropy/asdf-astropy/actions/runs/17032518373/job/48277987229#step:10:162

With this PR 4427 tests passed:
https://github.com/astropy/asdf-astropy/actions/runs/17048006142/job/48328626619?pr=291#step:10:160