### PR TITLE
skip galexsec time format test

### DIFF
--- a/asdf_astropy/converters/time/tests/test_time.py
+++ b/asdf_astropy/converters/time/tests/test_time.py
@@ -136,6 +136,10 @@ def create_formats():
             # stardate is not a documented format for astropy
             # https://docs.astropy.org/en/latest/time/index.html#time-format
             continue
+        if format_ == "galexsec":
+            # galexsec is unsupported until the time schema can be updated
+            # https://github.com/astropy/asdf-astropy/issues/292
+            continue
         new = Time("B2000.0")
         new.format = format_
         formats.append(new)


### PR DESCRIPTION
Astropy added a new `galexsec` time format. This is not listed in the time schema and will require an asdf-standard update and release to support (see https://github.com/astropy/asdf-astropy/issues/292).

Until then, this PR skips testing `galexsec` to fix our devdeps.