### PR TITLE
Avoid using the private `EarthLocation._get_site_registry()` in tests

### DIFF
--- a/asdf_astropy/converters/coordinates/tests/test_earth_location.py
+++ b/asdf_astropy/converters/coordinates/tests/test_earth_location.py
@@ -35,17 +35,8 @@ def test_serialization(earth_location, tmp_path):
         assert (af["earth_location"] == earth_location).all()
 
 
-@pytest.fixture
-def _builtin_site_registry():
-    orig_sites = getattr(EarthLocation, "_site_registry", None)
-    EarthLocation._get_site_registry(force_builtin=True)
-    yield
-    EarthLocation._site_registry = orig_sites
-
-
-@pytest.mark.usefixtures("_builtin_site_registry")
 def test_earthlocation_site(tmp_path):
-    earth_location = EarthLocation.of_site("greenwich")
+    earth_location = EarthLocation(lon=-0.001475 * u.deg, lat=51.477811 * u.deg, height=46 * u.m)
 
     file_path = tmp_path / "test.asdf"
     with asdf.AsdfFile() as af:

--- a/asdf_astropy/converters/coordinates/tests/test_earth_location.py
+++ b/asdf_astropy/converters/coordinates/tests/test_earth_location.py
@@ -5,8 +5,6 @@ from astropy.coordinates import EarthLocation, Latitude, Longitude
 from astropy.coordinates.earth import ELLIPSOIDS
 from astropy.units import Quantity
 
-from asdf_astropy.testing.helpers import assert_earth_location_equal
-
 
 def create_earth_locations():
     longitude = Longitude([0.0, 45.0, 90.0, 135.0, 180.0, -180, -90, -45], u.deg, wrap_angle=180 * u.deg)
@@ -33,15 +31,3 @@ def test_serialization(earth_location, tmp_path):
 
     with asdf.open(file_path) as af:
         assert (af["earth_location"] == earth_location).all()
-
-
-def test_earthlocation_site(tmp_path):
-    earth_location = EarthLocation(lon=-0.001475 * u.deg, lat=51.477811 * u.deg, height=46 * u.m)
-
-    file_path = tmp_path / "test.asdf"
-    with asdf.AsdfFile() as af:
-        af["earth_location"] = earth_location
-        af.write_to(file_path)
-
-    with asdf.open(file_path) as af:
-        assert_earth_location_equal(af["earth_location"], earth_location)


### PR DESCRIPTION
The development dependencies CI job is failing because the tests here rely on private `astropy` code that has been changed: https://github.com/astropy/asdf-astropy/actions/runs/18271678280/job/52015325062#step:10:201 Luckily the replacement code (in the first commit) that avoids private API is even simpler and also backwards-compatible.

It doesn't look to me like `test_earthlocation_site` is worth keeping at all because it just duplicates one of the parametrizations of `test_serialization`, so I removed it. The removal is in a separate commit so that it would be simple to undo in case it does serve some purpose.