### PR TITLE
fix magunit serialization to match unit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@
 
 - Add support for astronomy-1.2.0 manifest [#270]
 - Add TETE and TEME coordinate frames [#310]
+- Fix magunit serialization to match unit [#313]
 
 0.9.0 (2025-11-17)
 ------------------

--- a/asdf_astropy/converters/coordinates/tests/test_frame.py
+++ b/asdf_astropy/converters/coordinates/tests/test_frame.py
@@ -1,3 +1,4 @@
+import importlib.metadata
 import unittest.mock as mk
 
 import asdf
@@ -29,6 +30,12 @@ from astropy.time import Time
 
 from asdf_astropy.converters.coordinates.frame import FrameConverter, LegacyICRSConverter
 from asdf_astropy.testing.helpers import assert_frame_equal
+
+# skip TETE and TEME for old asdf-coordinates_schemas
+if importlib.metadata.version("asdf-coordinates-schemas") < "0.5.0":
+    TETE_MARKS = [pytest.mark.skip]
+else:
+    TETE_MARKS = []
 
 
 def create_frames():
@@ -71,10 +78,10 @@ def create_frames():
         PrecessedGeocentric(),
         PrecessedGeocentric(**test_data),
         PrecessedGeocentric(**test_data, equinox="B1975"),
-        TEME(obstime=Time("J2020")),
-        TEME(sky.represent_as("cartesian"), obstime=Time("J2020")),
-        TETE(),
-        TETE(**test_data, obstime=Time("J2020")),
+        pytest.param(TEME(obstime=Time("J2020")), marks=TETE_MARKS),
+        pytest.param(TEME(sky.represent_as("cartesian"), obstime=Time("J2020")), marks=TETE_MARKS),
+        pytest.param(TETE(), marks=TETE_MARKS),
+        pytest.param(TETE(**test_data, obstime=Time("J2020")), marks=TETE_MARKS),
     ]
 
 

--- a/asdf_astropy/converters/unit/magunit.py
+++ b/asdf_astropy/converters/unit/magunit.py
@@ -1,14 +1,31 @@
-from asdf.extension import Converter
+from asdf.versioning import split_tag_version
+
+from .unit import UnitConverter
 
 
-class MagUnitConverter(Converter):
+class MagUnitConverter(UnitConverter):
     tags = ("tag:astropy.org:astropy/units/magunit-*",)
     types = ("astropy.units.function.logarithmic.MagUnit",)
 
+    def select_tag(self, obj, tags, ctx):
+        return tags[-1]
+
     def to_yaml_tree(self, obj, tag, ctx):
-        return {"unit": obj.physical_unit}
+        _, version = split_tag_version(tag)
+
+        # version 1.0.0 uses a nested dictionary
+        if version == "1.0.0":
+            return {"unit": obj.physical_unit}
+
+        return super().to_yaml_tree(obj.physical_unit, tag, ctx)
 
     def from_yaml_tree(self, node, tag, ctx):
         from astropy.units import mag
 
-        return mag(node["unit"])
+        _, version = split_tag_version(tag)
+
+        # version 1.0.0 uses a nested dictionary
+        if version == "1.0.0":
+            return mag(node["unit"])
+
+        return mag(super().from_yaml_tree(node, tag, ctx))

--- a/asdf_astropy/converters/unit/tests/test_magunit.py
+++ b/asdf_astropy/converters/unit/tests/test_magunit.py
@@ -1,6 +1,7 @@
 import asdf
 import pytest
 from astropy import units
+from astropy.table import Column
 
 
 def create_builtin_units():
@@ -49,3 +50,16 @@ def test_magunit_serialization(unit, tmp_path):
 
     with file_path.open() as f:
         assert "tag:astropy.org:astropy/units/magunit-" in f.read()
+
+
+def test_magunit_in_column(tmp_path):
+    column = Column([1, 2, 3], unit=units.function.ABmag, name="foo")
+
+    file_path = tmp_path / "test.asdf"
+    with asdf.AsdfFile() as af:
+        af["column"] = column
+        af.write_to(file_path)
+
+    with asdf.open(file_path) as af:
+        # the column unit tests already cover the other attributes
+        assert af["column"].unit == column.unit

--- a/asdf_astropy/converters/unit/tests/test_magunit.py
+++ b/asdf_astropy/converters/unit/tests/test_magunit.py
@@ -56,7 +56,7 @@ def test_magunit_in_column(tmp_path):
     column = Column([1, 2, 3], unit=units.function.ABmag, name="foo")
 
     file_path = tmp_path / "test.asdf"
-    with asdf.AsdfFile() as af:
+    with asdf.AsdfFile(version="1.6.0") as af:
         af["column"] = column
         af.write_to(file_path)
 

--- a/asdf_astropy/extensions.py
+++ b/asdf_astropy/extensions.py
@@ -602,6 +602,7 @@ _UNIT_CONVERTERS = [
 CORE_CONVERTERS = _FITS_CONVERTERS + _TIME_CONVERTERS + _TABLE_CONVERTERS + _UNIT_CONVERTERS
 
 ASTROPY_UNIT_MANIFESTS = [
+    "asdf://astropy.org/astropy/manifests/units-1.3.0",
     "asdf://astropy.org/astropy/manifests/units-1.2.0",
     "asdf://astropy.org/astropy/manifests/units-1.1.0",
     "asdf://astropy.org/astropy/manifests/units-1.0.0",

--- a/asdf_astropy/resources/manifests/units-1.3.0.yaml
+++ b/asdf_astropy/resources/manifests/units-1.3.0.yaml
@@ -1,0 +1,35 @@
+
+id: asdf://astropy.org/astropy/manifests/units-1.3.0
+extension_uri: asdf://astropy.org/astropy/extensions/units-1.3.0
+title: Astropy unit extension
+description: |-
+  A set of tags to inject into asdf-standard to enable serializing astropy units
+  related objects
+asdf_standard_requirement:
+  gte: 1.6.0
+tags:
+  # unit/unit is duplicated from the core to allow the unit converter to select
+  # the core tag for vo units
+  - tag_uri: tag:stsci.edu:asdf/unit/unit-1.0.0
+    schema_uri: http://stsci.edu/schemas/asdf/unit/unit-1.0.0
+    title: Physical unit.
+    description: |-
+      This represents a physical unit, in [VOUnit syntax, Version 1.0](http://www.ivoa.net/documents/VOUnits/index.html).
+      Where units are not explicitly tagged, they are assumed to be in VOUnit syntax.
+  - tag_uri: tag:astropy.org:astropy/units/unit-1.0.0
+    schema_uri: http://stsci.edu/schemas/asdf/unit/unit-1.0.0
+    title: Represents an astropy derived unit
+    description: |-
+      Supports serialization of the non-VOunits supported by astropy
+  - tag_uri: tag:astropy.org:astropy/units/equivalency-1.2.0
+    schema_uri: http://astropy.org/schemas/astropy/units/equivalency-1.2.0
+    title: Represents unit equivalency.
+    description: |-
+      Supports serialization of equivalencies between units
+      in certain contexts
+  - tag_uri: tag:astropy.org:astropy/units/magunit-1.1.0
+    schema_uri: http://astropy.org/schemas/astropy/units/magunit-1.1.0
+    title: Represents a Magnitude Unit
+    description: |-
+      Represents the serialization of the MagUnit units built into
+      astropy.

--- a/asdf_astropy/resources/schemas/units/magunit-1.1.0.yaml
+++ b/asdf_astropy/resources/schemas/units/magunit-1.1.0.yaml
@@ -1,0 +1,14 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/units/magunit-1.1.0"
+
+title: |
+  Represents a Magnitude Unit
+
+description: |
+  Represents the serialization of the MagUnit units built into
+  astropy.
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/unit/unit-1.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,6 +155,9 @@ text_file_format = 'rst'
 filterwarnings = [
     'error',
     'ignore:numpy.ndarray size changed:RuntimeWarning',
+    # astropy triggers but doesn't handle a numpy warning, ignore it until
+    # astropy addresses it: https://github.com/astropy/astropy/issues/19216
+    'ignore:The chararray class is deprecated:DeprecationWarning',
 ]
 addopts = '--color=yes --doctest-rst'
 asdf_schema_root = 'asdf_astropy/resources/schemas'


### PR DESCRIPTION
The current magunit serialization (a dict with a "unit" key and serialized physical unit value) differs from unit serialization (a string) enough that it fails validation against the unit schema.

This makes magunit unusable in place of a "unit" which makes saving a `Column` with a magunit unit invalid.

This PR updates the magunit schema and converter so that it serializes as a string and is compatible with the unit schema.

I also included a few minor fixes to appease the CI:
- ignore the numpy chararray warning triggered by astropy (to fix devdeps)
- skip the TETE TEME tests for older versions of asdf-coordinate schemas which don't have the required manifest (to fix oldestdeps)

I ran romancal regtests since those test (with asdf-astropy dev) were what revealed the issue with magunit: https://github.com/spacetelescope/RegressionTests/actions/runs/21950429074
the failures are unrelated and importantly no `ValidationError`s are seen so I think this is ready to go.