### PR TITLE
switch manifest checks to version checks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-0.10.1 (unreleased)
+0.10.1 (2025-03-20)
 -------------------
 
 - Update version checks for transform schema compatibility to use package

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+0.10.1 (unreleased)
+-------------------
+
+- Update version checks for transform schema compatibility to use package
+  versions instead of manifests [#317]
+
 0.10.0 (2026-02-13)
 -------------------
 

--- a/asdf_astropy/extensions.py
+++ b/asdf_astropy/extensions.py
@@ -4,7 +4,6 @@ via an ``entry-point`` in the ``pyproject.toml`` file.
 """
 
 import importlib.metadata
-from importlib.util import find_spec
 
 import asdf
 from asdf.extension import Extension, ManifestExtension
@@ -426,19 +425,21 @@ TRANSFORM_MANIFEST_URIS = [
 # to avoid including the new tags until those libraries can be updated.
 # We make the assumption here that the next version of each
 # downstream library manifest will fix the issue.
-_REQUIRED_DOWNSTREAM_MANIFESTS = {
-    "dkist": "asdf://dkist.nso.edu/dkist/extensions/dkist-wcs-1.5.0",
-    "asdf_wcs_schemas": "asdf://asdf-format.org/astronomy/gwcs/extensions/gwcs-1.4.0",
-    "stdatamodels": "asdf://stsci.edu/jwst_pipeline/extensions/jwst_transforms-1.2.0",
+_REQUIRED_DOWNSTREAM_VERSIONS = {
+    "dkist": "1.14.0",
+    "asdf_wcs_schemas": "0.5.0",
+    "stdatamodels": "3.1.0",
 }
 _include_new_transforms = True
 _resource_manager = asdf.get_config().resource_manager
-for package_name, required_manifest_uri in _REQUIRED_DOWNSTREAM_MANIFESTS.items():
+for package_name, required_version in _REQUIRED_DOWNSTREAM_VERSIONS.items():
     # don't use astropy.utils.minversion as it imports the package
-    if find_spec(package_name) is None:
+    try:
+        version = importlib.metadata.version(package_name)
+    except importlib.metadata.PackageNotFoundError:
         # not installed
         continue
-    if required_manifest_uri not in _resource_manager:
+    if version < required_version:
         # don't include new manifest
         _include_new_transforms = False
         break


### PR DESCRIPTION
Now that the manifests are all released we can use version checks.

This fixes a bug where depending on import order and resource registration order some environments can satisfy the requirements for the new transform schema but asdf-astropy won't install them due to the manifest checks. Switching to package versions removes the dependence on import/registration order.

Running regtests for roman and jwst as this will be part of a bugfix release after merging:
jwst: https://github.com/spacetelescope/RegressionTests/actions/runs/23354126267
roman: https://github.com/spacetelescope/RegressionTests/actions/runs/23354114521