### PR TITLE
update workflow for trusted publishing

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -8,14 +8,30 @@ permissions:
   contents: read
 
 jobs:
-  build-n-publish:
+  build:
     permissions:
       contents: none
     if: (github.event_name == 'release')
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@e97344095b099e1d729fe97429078c9975921d8a  # v2.6.2
     with:
-      upload_to_pypi: true
+      upload_to_pypi: false
+      save_artifacts: true
       test_extras: test
       test_command: pytest --pyargs asdf_astropy
-    secrets:
-      pypi_token: ${{ secrets.PYPI_PASSWORD }}
+
+  upload:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    needs: [build]
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          merge-multiple: true
+          pattern: dist-*
+          path: dist
+      - name: Upload to PyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0


### PR DESCRIPTION
Closes https://github.com/astropy/asdf-astropy/issues/321

Update publish workflow to use trusted publishing.

I've configured pypi to trust this workflow.

Once this is in we can make a dev/alpha release to test the process.

https://github.com/braingram/asdf-astropy/actions/runs/24423796233/job/71353151823
is an attempt to test with testpypi (which I did not configure to trust this workflow, does testpypi support this?). I'm sharing that test since it shows that the general process is working where:
- the prior build/publish workflow step builds and uploads an artifact but does not attempt to publish
- the new publish workflow downloads the artifacts and attempts the upload