### PR TITLE
fix: parsing of jyear and byear times from ASDF

### DIFF
--- a/asdf_astropy/converters/time/tests/test_time.py
+++ b/asdf_astropy/converters/time/tests/test_time.py
@@ -71,6 +71,12 @@ def create_examples():
         },
         {
             "example": """!time/time-1.1.0
+          value: B2000.0
+          format: byear""",
+            "truth": Time("B2000.0", format="byear_str"),
+        },
+        {
+            "example": """!time/time-1.1.0
           ["2000-12-31T13:05:27.737", "2000-12-31T13:06:38.444"]""",
             "truth": Time(["2000-12-31T13:05:27.737", "2000-12-31T13:06:38.444"]),
         },
@@ -84,7 +90,12 @@ def create_examples():
         },
         {
             "example": """!time/time-1.1.0
-          value: !core/ndarray-1.0.0
+          value: J2000.0
+          format: jyear""",
+            "truth": Time("J2000.0", format="jyear_str")
+        },
+        {
+            "example": """!time/time-1.1.0
           value: 2000.0
           format: jyear
           scale: tdb
@@ -97,8 +108,7 @@ def create_examples():
               unit: !unit/unit-1.0.0 m
             z: !unit/quantity-1.1.0
               value: 0
-              unit: !unit/unit-1.0.0 m
-          format: jyear""",
+              unit: !unit/unit-1.0.0 m""",
             "truth": Time(
                 2000.0,
                 location=EarthLocation(x=6378100 * u.m, y=0 * u.m, z=0 * u.m),

--- a/asdf_astropy/converters/time/time.py
+++ b/asdf_astropy/converters/time/time.py
@@ -10,6 +10,8 @@ _ASTROPY_FORMAT_TO_ASDF_FORMAT = {
     "jyear_str": "jyear",
 }
 
+_EPOCH_PREFIX_FORMATS = {"jyear": ("jyear_str", "J"), "byear": ("byear_str", "B")}
+
 
 class TimeConverter(Converter):
     tags = ("tag:stsci.edu:asdf/time/time-*",)
@@ -101,9 +103,12 @@ class TimeConverter(Converter):
                     location["z"],
                 )
 
+        value = node["value"]
+        format = self._asdf_to_astropy_format(value, node.get("format"))
+
         time = Time(
-            node["value"],
-            format=node.get("format"),
+            value,
+            format=format,
             scale=node.get("scale"),
             location=location,
         )
@@ -113,3 +118,33 @@ class TimeConverter(Converter):
             time.format = base_format
 
         return time
+
+    @staticmethod
+    def _asdf_to_astropy_format(value, format):
+        if format not in _EPOCH_PREFIX_FORMATS:
+            return format
+
+        # Need a test scalar value to check if it's a string
+        if isinstance(value, list):
+            while value and isinstance(value, list):
+                value = value[0]
+
+            if not isinstance(value, str):
+                return format
+        elif isinstance(value, (np.ndarray, NDArrayType)):
+            if np.issubdtype(value.dtype, np.str_) and value.size > 0:
+                value = value.item()
+            else:
+                return format
+        elif not isinstance(value, str):
+            return format
+
+        # astropy.time has separate formats for Julian and Besselian year
+        # values with epoch prefixes; arguably this is a bit inflexible but
+        # we must fix up the format in this case.
+        new_format, prefix = _EPOCH_PREFIX_FORMATS[format]
+
+        if value[0] == prefix:
+            return new_format
+
+        return format


### PR DESCRIPTION
The schema allows `value: JXXXX.X` with `format: jyear` and likewise for Bessellian years.  Astropy is a bit overly strict in requiring the 'jyear_str' and 'byear_str' Time formats for these when instantiating a Time with a known format.

After experimenting with different approaches it seems, ufortunately, most reliable to refuse to guess, and instead take a test value (if the node value is an array or quantity) and check if it is a string starting with the appropriate prefix.

This came up in https://github.com/asdf-format/libasdf/pull/201 , as libasdf allows writing a time like:

```
obstime: !time/time-1.4.0
  value: J1948.78707178
  format: jyear
```

which is valid within the schema.

Arguably Astropy's behavior here is finicky and misleading:

```
>>> Time('J1948.78707178', format='jyear')
Traceback (most recent call last):
<... long traceback ...>
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  Cell In[37], line 1
    t = Time('J1948.78707178', format='jyear')
  File ~/src/asdf-format/asdf-astropy/.venv/lib/python3.12/site-packages/astropy/time/core.py:1991 in __init__
    self._init_from_vals(
  File ~/src/asdf-format/asdf-astropy/.venv/lib/python3.12/site-packages/astropy/time/core.py:559 in _init_from_vals
    self._time = self._get_time_fmt(
  File ~/src/asdf-format/asdf-astropy/.venv/lib/python3.12/site-packages/astropy/time/core.py:643 in _get_time_fmt
    raise ValueError(
ValueError: Input values did not match the format class jyear:
TypeError: for jyear class, input should be (long) doubles, string, or Decimal, and second values are only allowed for (long) doubles.
```

The error message is misleading because it says the input may be a "string", which it was.  But what it's looking for here is a bare decimal string like `2000.0`.

I can see why, for serialization purposes, Astropy has separate `'jyear'` and `'jyear_str'` formats (though arguably the latter should be a subformat of the former).  But I think it could stand to be a little more flexible on this too when there's no ambiguity.


Also fixed a bit of what appeared to be copy/paste detritus in one of the other existing test cases.